### PR TITLE
Upgrade the eaas-provision-space tekton bundle in the e2e pipeline

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -39,7 +39,7 @@ spec:
           - name: name
             value: eaas-provision-space
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-eaas-provision-space:0.1-0351e1e3df028e27e43877d9ca7e646be4ff2d65
+            value: quay.io/konflux-ci/tekton-catalog/task-eaas-provision-space:0.1-4e4fa7355a6a51083954408e7e3b647e3bddb8d8
           - name: kind
             value: task
       params:


### PR DESCRIPTION
The underlying method for provisioning was changed. See: https://github.com/konflux-ci/build-definitions/pull/1789

The `SpaceRequest` API will be removed from Konflux at some future date (TBD).