### PR TITLE
ci: add policy-controller to ptc pipeline

### DIFF
--- a/konflux-configs/releasePlans/promoteToCandidateRPs/components/overlays/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/components/overlays/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - cli
   - certificate-transparency-go
   - rekor-monitor
+  - policy-controller

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/components/overlays/policy-controller/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/components/overlays/policy-controller/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../components/base
+
+nameSuffix: policy-controller
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/components/overlays/policy-controller/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/components/overlays/policy-controller/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: policy-controller


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Added configuration for policy-controller in the release pipeline