### PR TITLE
fix: rename rhtas deployment name

### DIFF
--- a/tasks/install-operator-from-fbc.yaml
+++ b/tasks/install-operator-from-fbc.yaml
@@ -82,9 +82,9 @@ spec:
          oc get catalogsource tas-test -n openshift-marketplace -o yaml
         
         
-        until oc get deployment rhtas-operator-controller-manager -n openshift-operators &>/dev/null; do
+        until oc get deployment rhtas-controller-manager -n openshift-operators &>/dev/null; do
           echo "Waiting for the deployment to be created..."
           sleep 5
         done
-        oc wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=2m -n openshift-operators
+        oc wait --for=condition=available deployment/rhtas-controller-manager --timeout=2m -n openshift-operators
 

--- a/tasks/install-operator-from-image.yaml
+++ b/tasks/install-operator-from-image.yaml
@@ -64,4 +64,4 @@ spec:
           mountPath: /storage
       script: |
         oc create -k /storage/resources/config/env/openshift
-        oc wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=120s -n openshift-rhtas-operator
+        oc wait --for=condition=available deployment/rhtas-controller-manager --timeout=120s -n openshift-rhtas-operator


### PR DESCRIPTION
Change RHTAS operator deployment name to rhtas-controller-manager which has been caused because of cahnges in immutable sections which causes OLM upgrade to fail.

Refs: https://github.com/securesign/secure-sign-operator/pull/1110