### PR TITLE
feat: monorepo integration scenario to check snapshot redines

### DIFF
--- a/pipelines/monorepo-check.yaml
+++ b/pipelines/monorepo-check.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: monorepo-check
+spec:
+  description: |
+    Pipeline checks if a snapshot contains all the changes from the monorepo.
+    If not, it fails the test and prevents the snapshot from being auto-released.
+  params:
+    - description: Snapshot of the application
+      name: SNAPSHOT
+      type: string
+  tasks:
+    - name: test-snapshot-component
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/securesign/pipelines.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test-snapshot-component.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)

--- a/tasks/test-snapshot-component.yaml
+++ b/tasks/test-snapshot-component.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-snapshot-component
+spec:
+  params:
+    - name: SNAPSHOT
+      description: The JSON string of the Snapshot under test
+  steps:
+    - name: test-snapshot-component
+      image: quay.io/konflux-ci/konflux-test:stable
+      workingDir: /workspace
+      env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: SNAPSHOT_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/source-repo-url']
+        - name: SNAPSHOT_SHA
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sha']
+      script: |
+        #!/bin/bash
+        set -e
+        components=$(jq -c '.components[]' <<< "${SNAPSHOT}")
+        snapshotUrlUrlWithoutSuffix=$(echo $SNAPSHOT_URL | sed 's/\.git$//')
+        while read components
+        do
+          componentUrl=$(echo "$components" | jq -r '.source.git.url')
+          componentUrlWithoutSuffix=$(echo $componentUrl | sed 's/\.git$//')
+          name=$(echo "$components" | jq -r '.name')
+          componentSha=$(echo "$components" | jq -r '.source.git.revision')
+            # Check if component git url equals to snapshot git url, if yes check if the snapshot SHA equals to component SHA
+            if [[ $componentUrlWithoutSuffix == $snapshotUrlUrlWithoutSuffix ]]; then
+                if [[ $componentSha != $SNAPSHOT_SHA ]]; then
+                echo "FAIL: Component $name has different SHA: $componentSha than the snapshot, SHA: $SNAPSHOT_SHA."
+                exit 1
+                fi
+            fi
+          echo "SUCCESS: Component $name matches snapshot SHA."
+        done < <(echo "$components")


### PR DESCRIPTION
Components in snapshots has to be build from same commit sha.

It has been tested on snaphost:
 - accepted operator-46ghz
 - rejected operator-t58hb

Based on https://konflux.pages.redhat.com/docs/users/patterns/managing-monorepo-applications.html

## Summary by Sourcery

Introduce a Tekton Task and Pipeline to ensure snapshots include matching component commits from the same monorepo revision

New Features:
- Add test-snapshot-component Task to verify components in a snapshot share the same Git SHA as the snapshot source when URLs match
- Add monorepo-check Pipeline to run the snapshot component test and prevent auto-release of snapshots missing monorepo changes

## Summary by Sourcery

Introduce Tekton Task and Pipeline to validate that snapshots include components built from the same monorepo commit and prevent auto-release when mismatches are detected

New Features:
- Add test-snapshot-component Task to verify that each component in a snapshot matches the snapshot’s Git URL and commit SHA
- Add monorepo-check Pipeline to run the snapshot component test and block auto-release of snapshots missing monorepo changes