### PR TITLE
ci: Add v4-19 to release plans

### DIFF
--- a/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/overlays/fbc-v4-19/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/overlays/fbc-v4-19/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../fbc/base
+
+nameSuffix: fbc-v4-19
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/overlays/fbc-v4-19/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/overlays/fbc-v4-19/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: fbc-v4-19

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/overlays/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/overlays/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - fbc-v4-16
   - fbc-v4-17
   - fbc-v4-18
+  - fbc-v4-19


### PR DESCRIPTION
## Summary by Sourcery

Add fbc v4-19 to the promote-to-candidate release plans

CI:
- Include fbc-v4-19 in the promote-to-candidate overlay list
- Create a new kustomize overlay and ReleasePlan patch for fbc-v4-19