### PR TITLE
Add policy-controller-operator e2e pipeline

### DIFF
--- a/pipelines/policy-controller-operator-e2e.yaml
+++ b/pipelines/policy-controller-operator-e2e.yaml
@@ -1,0 +1,475 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: policy-controller-operator-e2e
+spec:
+  description: |
+    An integration test which provisions an ephemeral Hypershift cluster, deploys the policy controller operator
+    from a Konflux snapshot and run the e2e test suite.
+  params:
+    - description: Snapshot of the application
+      name: SNAPSHOT
+      type: string
+    - description: OCP version
+      name: OCP_VERSION
+      type: string
+      default: "4.17"
+    - description: Namespace where the the Operator bundle will be deployed.
+      name: NAMESPACE
+      default: default
+      type: string
+    - description: RHTAS Bundle image
+      name: RHTAS_BUNDLE_IMAGE
+      default: registry.redhat.io/rhtas/rhtas-operator-bundle:1.2.0
+      type: string
+    - description: RHTAS git url
+      name: RHTAS_GIT_URL
+      default: https://github.com/securesign/secure-sign-operator
+      type: string
+    - description: RHTAS git revision
+      name: RHTAS_GIT_REVISION
+      default: main
+      type: string
+    - description: Namespace where TAS will be installed
+      name: TAS_E2E_NAMESPACE
+      default: tas-e2e
+      type: string
+    - description: Namespace where Policy Controller will be installed
+      name: POLICY_CONTROLLER_OPERATOR_NS
+      default: policy-controller-operator
+      type: string
+  tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/securesign/pipelines.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/parse-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: provision-eaas-space
+      runAfter:
+        - parse-metadata
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: eaas-provision-space
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-eaas-provision-space:0.1-4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: kind
+            value: task
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-cluster
+      runAfter:
+        - provision-eaas-space
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "$(params.OCP_VERSION)"
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: m5.large
+              - name: timeout
+                value: 60m
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/rhtas/policy-controller-rhel9
+                    mirrors:
+                      - quay.io/securesign/policy-controller
+                  - source: registry.redhat.io/rhtas/policy-controller-rhel9-operator 
+                    mirrors:
+                      - quay.io/securesign/policy-controller-operator
+                  - source: registry.redhat.io/rhtas/policy-controller-operator-bundle 
+                    mirrors:
+                    - quay.io/securesign/policy-controller-operator-bundle
+    - name: install-rhtas-operator
+      runAfter:
+        - provision-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/securesign/pipelines.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/install-operator-from-bundle.yaml
+      params:
+        - name: eaasSpaceSecretRef
+          value: $(tasks.provision-eaas-space.results.secretRef)
+        - name: clusterName
+          value: "$(tasks.provision-cluster.results.clusterName)"
+        - name: bundleImage
+          value: "$(params.RHTAS_BUNDLE_IMAGE)"
+        - name: namespace
+          value: "$(params.NAMESPACE)"
+    - name: install-securesign
+      runAfter:
+        - install-rhtas-operator
+      params:
+        - name: namespace
+          value: "$(params.NAMESPACE)"
+      taskSpec:
+        results:
+          - name: oidc-hostname
+            value: "$(steps.install-keycloak.results.oidc-hostname)"
+        volumes:
+          - name: credentials
+            emptyDir: { }
+          - name: repository
+            emptyDir: { }
+          - name: binaries
+            emptyDir: { }
+          - name: dump
+            emptyDir: { }
+          - name: push-creds
+            secret:
+              secretName: securesign-test-dump-oci
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: git-clone-operator
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/securesign/pipelines.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/git-clone-operator.yaml
+            params:
+              - name: operator-component
+                value: "$(tasks.parse-metadata.results.component)"
+              - name: git-url
+                value: "$(params.RHTAS_GIT_URL)"
+              - name: git-revision
+                value: "$(params.RHTAS_GIT_REVISION)"
+              - name: repository
+                value: repository
+          - name: install-keycloak
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/securesign/pipelines.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/install-keycloak.yaml
+            params:
+              - name: credentials
+                value: credentials
+              - name: repository
+                value: repository
+              - name: KUBECONFIG
+                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: workdir
+                value: source
+          - name: install-tas
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/securesign/pipelines.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/install-tas.yaml
+            params:
+              - name: credentials
+                value: credentials
+              - name: repository
+                value: repository
+              - name: KUBECONFIG
+                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: workdir
+                value: source
+              - name: tas-namespace
+                value: "$(params.TAS_E2E_NAMESPACE)"
+              - name: OIDC_HOST
+                value: "$(steps.install-keycloak.results.oidc-hostname)"
+    - name: install-operator-from-bundle
+      runAfter:
+        - install-securesign
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/securesign/pipelines.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/install-operator-from-bundle.yaml
+      params:
+        - name: eaasSpaceSecretRef
+          value: $(tasks.provision-eaas-space.results.secretRef)
+        - name: clusterName
+          value: "$(tasks.provision-cluster.results.clusterName)"
+        - name: bundleImage
+          value: "$(tasks.parse-metadata.results.image)"
+        - name: namespace
+          value: "$(params.NAMESPACE)"
+      when:
+        - input: "$(tasks.parse-metadata.results.component)"
+          operator: in
+          values: [ "policy-controller-operator-bundle" ]
+    - name: install-operator-from-image
+      runAfter:
+        - install-securesign
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/securesign/pipelines.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/install-operator-from-image.yaml
+      params:
+        - name: eaasSpaceSecretRef
+          value: $(tasks.provision-eaas-space.results.secretRef)
+        - name: clusterName
+          value: "$(tasks.provision-cluster.results.clusterName)"
+        - name: operatorImage
+          value: "$(tasks.parse-metadata.results.image)"
+        - name: namespace
+          value: "$(params.POLICY_CONTROLLER_OPERATOR_NS)"
+        - name: resources_url
+          value: "$(tasks.parse-metadata.results.git-url).git/config/openshift?ref=$(tasks.parse-metadata.results.git-revision)"
+        - name: resources_path
+          value: "config/openshift"
+        - name: deployName
+          value: "policy-op-controller-manager"
+      when:
+        - input: "$(tasks.parse-metadata.results.component)"
+          operator: in
+          values: [ "policy-controller-operator"]
+    ## TODO:
+    # - name: install-operator-from-fbc
+    #   timeout: "0h5m0s"
+    #   runAfter:
+    #     - install-securesign
+    #   taskRef:
+    #     resolver: git
+    #     params:
+    #       - name: url
+    #         value: https://github.com/securesign/pipelines.git
+    #       - name: revision
+    #         value: main
+    #       - name: pathInRepo
+    #         value: tasks/install-operator-from-fbc.yaml
+    #   params:
+    #     - name: eaasSpaceSecretRef
+    #       value: $(tasks.provision-eaas-space.results.secretRef)
+    #     - name: clusterName
+    #       value: "$(tasks.provision-cluster.results.clusterName)"
+    #     - name: fbcImage
+    #       value: "$(tasks.parse-metadata.results.image)"
+    #     - name: namespace
+    #       value: "$(params.NAMESPACE)"
+    #   when:
+    #     - input: "$(tasks.parse-metadata.results.component)"
+    #       operator: in
+    #       values: ["fbc-v4-18", "fbc-v4-17", "fbc-v4-16", "fbc-v4-15", "fbc-v4-14", "fbc-v4-18-v1-1", "fbc-v4-17-v1-1", "fbc-v4-16-v1-1", "fbc-v4-15-v1-1", "fbc-v4-14-v1-1" ]
+    - name: policy-controller-e2e
+      runAfter:
+        - install-operator-from-image
+        - install-operator-from-bundle
+        # - install-operator-from-fbc
+      params:
+        - name: namespace
+          value: "$(params.NAMESPACE)"
+      taskSpec:
+        volumes:
+          - name: credentials
+            emptyDir: { }
+          - name: repository
+            emptyDir: { }
+          - name: binaries
+            emptyDir: { }
+          - name: dump
+            emptyDir: { }
+        steps:
+          - name: get-cosign
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/securesign/pipelines.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/extract-cosign.yaml
+            params:
+              - name: volume
+                value: binaries
+          - name: get-oc
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/securesign/pipelines.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/extract-oc.yaml
+            params:
+              - name: volume
+                value: binaries
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: push-test-image
+            image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+            results:
+              - name: image
+                type: string
+            securityContext:
+              capabilities:
+                add:
+                  - SETFCAP
+            computeResources:
+              limits:
+                memory: 8Gi
+              requests:
+                memory: 2Gi
+                cpu: '1'
+            script: |
+              #!/bin/sh
+              IMAGE=ttl.sh/test-$(date +%Y%m%d%H%M%S%N):latest
+              printf "%s" "$IMAGE" > "$(step.results.image.path)"
+              buildah pull alpine:latest
+              buildah tag alpine:latest $IMAGE
+              buildah push $IMAGE
+          - name: git-clone-operator
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/securesign/pipelines.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/git-clone-operator.yaml
+            params:
+              - name: operator-component
+                value: "$(tasks.parse-metadata.results.component)"
+              - name: git-url
+                value: "$(tasks.parse-metadata.results.git-url)"
+              - name: git-revision
+                value: "$(tasks.parse-metadata.results.git-revision)"
+              - name: repository
+                value: repository
+          - name: execute-operator-e2e
+            image: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:4805e1cb2d1bd9d3c5de5d6986056bbda94ca7b01642f721d83d26579d333c60
+            env:
+              - name: OIDC_HOST
+                value: "$(tasks.install-securesign.results.oidc-hostname)"
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: RHTAS_INSTALL_NAMESPACE
+                value: "$(params.TAS_E2E_NAMESPACE)"
+              - name: TEST_IMAGE
+                value: "$(steps.push-test-image.results.image)"
+              - name: POLICY_CONTROLLER_OPERATOR_NS
+                value: "$(params.POLICY_CONTROLLER_OPERATOR_NS)"
+            volumeMounts:
+              - name: repository
+                mountPath: /repository
+              - name: binaries
+                mountPath: /binaries
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/bin/sh
+              set +e -o pipefail
+              cd /repository/source
+              export PATH="$PATH:/binaries"
+              openssl s_client -connect "$OIDC_HOST:443" -showcerts </dev/null > /tmp/ssl.cert
+              sed -ni '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' /tmp/ssl.cert
+              cat /tmp/ssl.cert >> /etc/pki/tls/certs/ca-bundle.crt
+              export SSL_CERT_FILE=/tmp/ssl.cert
+              export INJECT_CA=true
+
+              source ./test/tas-env-variables.sh
+              go mod vendor
+              make e2e-test
+              status=$?
+
+              if [[ $status -ne 0 ]]; then
+                pods=$(oc get pods -n "$POLICY_CONTROLLER_OPERATOR_NS" -o jsonpath='{.items[*].metadata.name}')
+                for pod in $pods; do
+                  echo "===== logs for $pod ====="
+                  oc logs -n "$POLICY_CONTROLLER_OPERATOR_NS" --all-containers --prefix "$pod" "$pod" || true
+                done
+              fi
+
+              exit "$status"

--- a/stepactions/extract-oc.yaml
+++ b/stepactions/extract-oc.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: extract-oc
+spec:
+  description: >-
+    This StepAction extract oc binary from image to specified volume.
+  image: registry.redhat.io/openshift4/ose-cli:latest
+  params:
+    - name: volume
+      type: string
+      description: Name of the volume to be used for extraction.
+    - name: volumePath
+      type: string
+      description: The directory path to use.
+      default: ""
+  volumeMounts:
+    - name: "$(params.volume)"
+      mountPath: /binaries
+  env:
+    - name: VOLUME_PATH
+      value: "$(params.volumePath)"
+  script: |
+    mkdir -p /binaries$VOLUME_PATH
+    cp /usr/bin/oc /binaries$VOLUME_PATH

--- a/stepactions/git-clone-operator.yaml
+++ b/stepactions/git-clone-operator.yaml
@@ -31,7 +31,7 @@ spec:
       value: "$(params.git-revision)"
   script: |
     cd /repository
-    if [[ "$OPERATOR_COMPONENT" == "rhtas-operator" || "$OPERATOR_COMPONENT" == "rhtas-operator-bundle" ]]; then
+    if [[ "$OPERATOR_COMPONENT" != "rhtas-operator" && "$OPERATOR_COMPONENT" != "rhtas-operator-bundle" ]]; then
       echo "Cloning from $GIT_URL"
       git clone $GIT_URL source
       cd source

--- a/tasks/install-operator-from-image.yaml
+++ b/tasks/install-operator-from-image.yaml
@@ -14,8 +14,15 @@ spec:
       description: Operator image to be installed
     - name: namespace
       description: Namespace to be used for installation
+      default: openshift-rhtas-operator
     - name: resources_url
       description: Resource directory to be kustomized and applied
+    - name: resources_path
+      description: Resource directory to be kustomized and applied
+      default: config/env/openshift
+    - name: deployName
+      description: Name of the operators deployment
+      default: rhtas-operator-controller-manager
   volumes:
     - name: credentials
       emptyDir: { }
@@ -50,7 +57,7 @@ spec:
         kustomize localize --no-verify "$(params.resources_url)" /storage/resources
         cd /storage/resources/config/manager && kustomize edit set image controller=$(params.operatorImage)
         echo "I am going to install following resources"
-        kustomize build /storage/resources/config/env/openshift
+        kustomize build /storage/resources/$(params.resources_path)
 
     - name: run-operator
       image: registry.redhat.io/openshift4/ose-cli
@@ -63,5 +70,5 @@ spec:
         - name: resources
           mountPath: /storage
       script: |
-        oc create -k /storage/resources/config/env/openshift
-        oc wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=120s -n openshift-rhtas-operator
+        oc create -k /storage/resources/$(params.resources_path)
+        oc wait --for=condition=available deployment/$(params.deployName) --timeout=120s -n $(params.namespace)


### PR DESCRIPTION
Pr to add a pipeline to run the policy controller e2e
https://github.com/securesign/policy-controller-operator/pull/17

## Summary by Sourcery

Add a new Tekton-based e2e testing pipeline for the policy-controller-operator and refine existing tasks for greater configurability and correct cloning behavior.

New Features:
- Introduce a policy-controller-operator-e2e Tekton pipeline to provision a Hypershift cluster, deploy the policy controller operator from snapshots or bundles, and execute the e2e test suite.
- Add an extract-oc StepAction to extract the oc binary into a specified volume for pipeline tasks.

Bug Fixes:
- Fix git-clone-operator step to clone only when the operator component is not rhtas-operator or rhtas-operator-bundle.

Enhancements:
- Parameterize the install-operator-from-image task with resources_path, deployName, and a default namespace to support dynamic kustomize paths and deployment targets.