### PR TITLE
Updating env var to clone git repo

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -22,10 +22,6 @@ spec:
       name: TAS_E2E_NAMESPACE
       default: tas-e2e
       type: string
-    - description: Operator Repo Url
-      name: OPERATOR_URL
-      default: https://github.com/securesign/secure-sign-operator.git
-      type: string
   tasks:
     - name: parse-metadata
       taskRef:
@@ -302,7 +298,7 @@ spec:
               - name: operator-component
                 value: "$(tasks.parse-metadata.results.component)"
               - name: git-url
-                value: "$(params.OPERATOR_URL)"
+                value: "$(tasks.parse-metadata.results.git-url)"
               - name: git-revision
                 value: "$(tasks.parse-metadata.results.git-revision)"
               - name: repository
@@ -404,7 +400,7 @@ spec:
               - name: operator-component
                 value: "$(tasks.parse-metadata.results.component)"
               - name: git-url
-                value: "$(params.OPERATOR_URL)"
+                value: "$(tasks.parse-metadata.results.git-url)"
               - name: git-revision
                 value: "$(tasks.parse-metadata.results.git-revision)"
               - name: repository
@@ -537,7 +533,7 @@ spec:
               - name: operator-component
                 value: "$(tasks.parse-metadata.results.component)"
               - name: git-url
-                value: "$(params.OPERATOR_URL)"
+                value: "$(tasks.parse-metadata.results.git-url)"
               - name: git-revision
                 value: "$(tasks.parse-metadata.results.git-revision)"
               - name: repository


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct GIT_URL to use tasks.parse-metadata.results.git-url instead of params.git-url