### PR TITLE
Freezing Pipelines

### DIFF
--- a/konflux-configs/releasePlans/promoteToCandidateRPs/components/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/components/base/releaseplan.yaml
@@ -13,7 +13,7 @@ spec:
     - name: git-url
       value: https://github.com/securesign/releases
     - name: code-freeze
-      value: "false"
+      value: "true"
     - name: type
       value: "component"
     serviceAccountName: rhtas-build-bot

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/base/releaseplan.yaml
@@ -13,7 +13,7 @@ spec:
     - name: git-url
       value: https://github.com/securesign/releases
     - name: code-freeze
-      value: "false"
+      value: "true"
     - name: type
       value: "fbc"
     serviceAccountName: rhtas-build-bot

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/operator/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/operator/base/releaseplan.yaml
@@ -13,7 +13,7 @@ spec:
     - name: git-url
       value: https://github.com/securesign/releases
     - name: code-freeze
-      value: "false"
+      value: "true"
     - name: type
       value: "operator"
     serviceAccountName: rhtas-build-bot


### PR DESCRIPTION
## Summary by Sourcery

Enable code freeze in promote-to-candidate release plans for components, FBC, and operator

Enhancements:
- Set the 'code-freeze' parameter to true in the components release plan
- Set the 'code-freeze' parameter to true in the FBC release plan
- Set the 'code-freeze' parameter to true in the operator release plan