### PR TITLE
Unfreezing pipelines

### DIFF
--- a/konflux-configs/releasePlans/promoteToCandidateRPs/components/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/components/base/releaseplan.yaml
@@ -13,7 +13,7 @@ spec:
     - name: git-url
       value: https://github.com/securesign/releases
     - name: code-freeze
-      value: "true"
+      value: "false"
     - name: type
       value: "component"
     serviceAccountName: rhtas-build-bot


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Disable code-freeze parameter in promoteToCandidateRPs release plan