### PR TITLE
Freezing Pipelines

### DIFF
--- a/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/fbc/base/releaseplan.yaml
@@ -13,7 +13,7 @@ spec:
     - name: git-url
       value: https://github.com/securesign/releases
     - name: code-freeze
-      value: "false"
+      value: "true"
     - name: type
       value: "fbc"
     serviceAccountName: rhtas-build-bot

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/operator/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/operator/base/releaseplan.yaml
@@ -13,7 +13,7 @@ spec:
     - name: git-url
       value: https://github.com/securesign/releases
     - name: code-freeze
-      value: "false"
+      value: "true"
     - name: type
       value: "operator"
     serviceAccountName: rhtas-build-bot


### PR DESCRIPTION
## Summary by Sourcery

Enable code-freeze in promote-to-candidate release plans for FBC and Operator pipelines

Enhancements:
- Set the code-freeze flag to true in the FBC promote-to-candidate release plan
- Set the code-freeze flag to true in the Operator promote-to-candidate release plan