### PR TITLE
feat: bumping go builder image to 1.24

### DIFF
--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -86,7 +86,7 @@ spec:
   - description: The Go base image used to run the unit tests
     name: go_base_image
     type: string
-    default: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:6a4a05d24acecde63d9c7c8c986ad9e5e20da2c2ce30312b328ed771736e7a1f
+    default: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
   results:
   - description: ""
     name: IMAGE_URL

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -104,7 +104,7 @@ spec:
   - description: The Go base image used to run the unit tests
     name: go_base_image
     type: string
-    default: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:6a4a05d24acecde63d9c7c8c986ad9e5e20da2c2ce30312b328ed771736e7a1f
+    default: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
   results:
   - description: ""
     name: IMAGE_URL

--- a/tasks/go-unit-test-oci-ta.yaml
+++ b/tasks/go-unit-test-oci-ta.yaml
@@ -21,7 +21,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: GO_BASE_IMAGE
       type: string
-      default: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:6a4a05d24acecde63d9c7c8c986ad9e5e20da2c2ce30312b328ed771736e7a1f
+      default: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir

--- a/tasks/go-unit-test.yaml
+++ b/tasks/go-unit-test.yaml
@@ -15,7 +15,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: GO_BASE_IMAGE
       type: string
-      default: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:6a4a05d24acecde63d9c7c8c986ad9e5e20da2c2ce30312b328ed771736e7a1f
+      default: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
   steps:
     - name: run-tests
       image:  $(params.GO_BASE_IMAGE)


### PR DESCRIPTION
## Summary by Sourcery

Bump Go builder image version from 1.23 to 1.24 across Tekton pipelines and tasks

Enhancements:
- Update default Go base image in docker-build-oci-ta pipeline to registry.redhat.io/ubi9/go-toolset:1.24
- Update default Go base image in docker-build pipeline to registry.redhat.io/ubi9/go-toolset:1.24
- Update default Go base image in go-unit-test-oci-ta task to registry.redhat.io/ubi9/go-toolset:1.24
- Update default Go base image in go-unit-test task to registry.redhat.io/ubi9/go-toolset:1.24