### PR TITLE
fix: oc wait in install operator from image task

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -203,8 +203,6 @@ spec:
           value: "$(tasks.provision-cluster.results.clusterName)"
         - name: operatorImage
           value: "$(tasks.parse-metadata.results.image)"
-        - name: namespace
-          value: "$(params.NAMESPACE)"
         - name: resources_url
           value: "$(tasks.parse-metadata.results.git-url).git/config/env/openshift?ref=$(tasks.parse-metadata.results.git-revision)"
       # use CEL regexp once it moves from alpha (see https://tekton.dev/docs/pipelines/pipelines/#use-cel-expression-in-whenexpression)


### PR DESCRIPTION
Task uses incorrect default namespace forcing to use openshift-rhtas-operator.

## Summary by Sourcery

Bug Fixes:
- Stop passing the namespace parameter to the operator installation task, fixing the oc wait NotFound error