### PR TITLE
ci: update-pco-to-1.24

### DIFF
--- a/pipelines/policy-controller-operator-e2e.yaml
+++ b/pipelines/policy-controller-operator-e2e.yaml
@@ -388,7 +388,7 @@ spec:
               - name: credentials
                 value: credentials
           - name: git-clone-policy-controller
-            image: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467
+            image: registry.redhat.io/ubi9/go-toolset:9.6@sha256:a90b4605b47c396c74de55f574d0f9e03b24ca177dec54782f86cdf702c97dbc
             env:
               - name: GIT_URL
                 value: "$(tasks.parse-metadata.results.git-url)"
@@ -406,7 +406,7 @@ spec:
               cd source
               git checkout $GIT_REVISION
           - name: execute-operator-e2e
-            image: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467
+            image: registry.redhat.io/ubi9/go-toolset:9.6@sha256:a90b4605b47c396c74de55f574d0f9e03b24ca177dec54782f86cdf702c97dbc
             env:
               - name: OIDC_HOST
                 value: "$(tasks.install-securesign.results.oidc-hostname)"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 images with registry.redhat.io/ubi9/go-toolset:9.6 in git-clone-policy-controller and execute-operator-e2e tasks