### PR TITLE
fix: Set correct parameters for git clone

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -298,9 +298,9 @@ spec:
                   value: stepactions/git-clone.yaml
             params:
               - name: url
-                value: "$(tasks.parse-metadata.results.git-url)"
+                value: "$(tasks.parse-metadata.results.operator-url)"
               - name: revision
-                value: "$(tasks.parse-metadata.results.git-revision)"
+                value: "$(tasks.parse-metadata.results.operator-revision)"
               - name: repository
                 value: repository
           - name: install-keycloak
@@ -350,14 +350,14 @@ spec:
                 - name: url
                   value: https://github.com/securesign/pipelines.git
                 - name: revision
-                  value: fix-e2e-for-1.2
+                  value: main
                 - name: pathInRepo
                   value: stepactions/git-clone.yaml
             params:
               - name: url
-                value: "$(tasks.parse-metadata.results.git-url)"
+                value: "$(tasks.parse-metadata.results.operator-url)"
               - name: revision
-                value: "$(tasks.parse-metadata.results.git-revision)"
+                value: "$(tasks.parse-metadata.results.operator-revision)"
               - name: repository
                 value: repository
           - name: get-tuftool
@@ -532,9 +532,9 @@ spec:
                   value: stepactions/git-clone.yaml
             params:
               - name: url
-                value: "$(tasks.parse-metadata.results.git-url)"
+                value: "$(tasks.parse-metadata.results.operator-url)"
               - name: revision
-                value: "$(tasks.parse-metadata.results.git-revision)"
+                value: "$(tasks.parse-metadata.results.operator-revision)"
               - name: repository
                 value: repository
           - name: git-clone-sigstore-e2e

--- a/tasks/parse-metadata.yaml
+++ b/tasks/parse-metadata.yaml
@@ -16,6 +16,10 @@ spec:
       description: "Stores information about the component's source url."
     - name: git-revision
       description: "Stores information about the component's source revision."
+    - name: operator-url
+      description: "Stores information about the rhtas-operator source url."
+    - name: operator-revision
+      description: "Stores information about the rhtas-operator's source revision."
   params:
     - name: SNAPSHOT
       description: The JSON string of the Snapshot under test
@@ -49,6 +53,16 @@ spec:
         GIT_URL=$(jq -r --arg component_name "${COMPONENT_NAME}" '.components[] | select(.name == $component_name) | .source.git.url' <<< "${SNAPSHOT}")
         GIT_REVISION=$(jq -r --arg component_name "${COMPONENT_NAME}" '.components[] | select(.name == $component_name) | .source.git.revision' <<< "${SNAPSHOT}")
 
+  
+        if [[ "$COMPONENT_NAME" =~ ^rhtas-operator.* ]]; then
+          OPERATOR_URL=$GIT_URL
+          OPERATOR_REVISION=$GIT_REVISION
+        else
+          #use default values
+          OPERATOR_URL="https://github.com/securesign/secure-sign-operator.git"
+          OPERATOR_REVISION="main"
+        fi
+
         # Log declared environment variables
         echo "Snapshot metadata:"
         echo "  SNAPSHOT: ${SNAPSHOT}"
@@ -58,6 +72,8 @@ spec:
         echo "  IMAGE: ${IMAGE}"
         echo "  GIT_URL: ${GIT_URL}"
         echo "  GIT_REVISION: ${GIT_REVISION}"
+        echo "  OPERATOR_URL: ${OPERATOR_URL}"
+        echo "  OPERATOR_REVISION: ${OPERATOR_REVISION}"
 
         # Write each environment variable to its respective results:
         echo -n "${EVENT_TYPE}" > $(results.test-event-type.path)
@@ -66,3 +82,5 @@ spec:
         echo -n "${IMAGE}" > $(results.image.path)
         echo -n "${GIT_URL}" > $(results.git-url.path)
         echo -n "${GIT_REVISION}" > $(results.git-revision.path)
+        echo -n "${OPERATOR_URL}" > $(results.operator-url.path)
+        echo -n "${OPERATOR_REVISION}" > $(results.operator-revision.path)


### PR DESCRIPTION
## Summary by Sourcery

Add operator-specific git clone parameters to parse-metadata and update rhtas-operator E2E pipeline to use them

New Features:
- Expose operator-url and operator-revision from the parse-metadata task

Bug Fixes:
- Use operator-url and operator-revision results for git-clone steps in the rhtas-operator-e2e pipeline instead of component parameters

Enhancements:
- Provide default operator URL and revision for non-operator components in parse-metadata
- Bump pipeline task and git-clone action revisions to the correct branches