### PR TITLE
fix: Use PipelineRun name as tag for test dump to prevent overrides

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -463,7 +463,7 @@ spec:
                   value: stepactions/secure-push-oci.yaml
             params:
               - name: oci-ref
-                value: "quay.io/securesign/test-dump-oci:$(tasks.parse-metadata.results.git-revision)"
+                value: "quay.io/securesign/test-dump-oci:$(context.pipelineRun.name)"
               - name: credentials-volume-name
                 value: push-creds
               - name: artifacts-volume-name


### PR DESCRIPTION
Switched from commit SHA to PipelineRun name for image tags to prevent overrides caused by parallel pipeline runs on the same commit. This ensures unique tags and preserves all test results.