### PR TITLE
Updating operator revision

### DIFF
--- a/tasks/parse-metadata.yaml
+++ b/tasks/parse-metadata.yaml
@@ -60,7 +60,7 @@ spec:
         else
           #use default values
           OPERATOR_URL="https://github.com/securesign/secure-sign-operator.git"
-          OPERATOR_REVISION="main"
+          OPERATOR_REVISION="release-1.2"
         fi
 
         # Log declared environment variables


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change default OPERATOR_REVISION from “main” to “release-1.2” in tasks/parse-metadata.yaml