### PR TITLE
Tdalton/release branch tweaks

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -293,7 +293,7 @@ spec:
                 - name: url
                   value: https://github.com/securesign/pipelines.git
                 - name: revision
-                  value: main
+                  value: "release-1.2"
                 - name: pathInRepo
                   value: stepactions/git-clone.yaml
             params:

--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -30,7 +30,7 @@ spec:
           - name: url
             value: https://github.com/securesign/pipelines.git
           - name: revision
-            value: main
+            value: release-1.2
           - name: pathInRepo
             value: tasks/parse-metadata.yaml
       params:

--- a/tasks/parse-metadata.yaml
+++ b/tasks/parse-metadata.yaml
@@ -60,7 +60,7 @@ spec:
         else
           #use default values
           OPERATOR_URL="https://github.com/securesign/secure-sign-operator.git"
-          OPERATOR_REVISION="release-1.2"
+          OPERATOR_REVISION="main"
         fi
 
         # Log declared environment variables


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update rhtas-operator-e2e pipeline to reference release-1.2 branch for both parse-metadata and git-clone tasks