### PR TITLE
chore: bump to clamav-scan v0.3

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -464,7 +464,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -455,7 +455,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -455,7 +455,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -463,7 +463,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Changes all build pipelines to utilize the latest version of clamav-scan which should help to significantly reduce the time required for this code scan.

## Summary by Sourcery

Update all build pipelines to use clamav-scan v0.3 to reduce code scan duration

Build:
- Bump clamav-scan task version from 0.2 to 0.3 in bundle-build-oci-ta pipeline
- Bump clamav-scan task version from 0.2 to 0.3 in docker-build-multi-platform-oci-ta pipeline
- Bump clamav-scan task version from 0.2 to 0.3 in docker-build-oci-ta pipeline
- Bump clamav-scan task version from 0.2 to 0.3 in docker-build pipeline