### PR TITLE
Add policy controller operator release plans

### DIFF
--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/base/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - releaseplan.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/base/releaseplan.yaml
@@ -7,7 +7,7 @@ metadata:
   name: promote-to-candidate-
   namespace: rhtas-tenant
 spec:
-  application: policy-controller
+  application: application
   tenantPipeline:
     params:
     - name: git-url
@@ -15,6 +15,16 @@ spec:
     - name: code-freeze
       value: "false"
     - name: type
-      value: "component"
+      value: "fbc"
     - name: file-name
-      value: "policy-controller.json"
+      value: "policy-controller-operator-fbc.json"
+    serviceAccountName: rhtas-build-bot
+    pipelineRef:
+      resolver: git
+      params:
+        - name: url
+          value: "https://github.com/securesign/pipelines"
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: "pipelines/promote-to-candidate.yaml"

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - pco-fbc-v4-14
+  - pco-fbc-v4-15
+  - pco-fbc-v4-16
+  - pco-fbc-v4-17
+  - pco-fbc-v4-18
+  - pco-fbc-v4-19

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-14/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-14/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../pco-fbc/base
+
+nameSuffix: pco-fbc-v4-14
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-14/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-14/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: pco-fbc-v4-14

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-15/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-15/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../pco-fbc/base
+
+nameSuffix: pco-fbc-v4-15
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-15/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-15/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: pco-fbc-v4-15

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-16/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-16/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../pco-fbc/base
+
+nameSuffix: pco-fbc-v4-16
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-16/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-16/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: pco-fbc-v4-16

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-17/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-17/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../pco-fbc/base
+
+nameSuffix: pco-fbc-v4-17
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-17/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-17/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: pco-fbc-v4-17

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-18/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-18/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../pco-fbc/base
+
+nameSuffix: pco-fbc-v4-18
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-18/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-18/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: pco-fbc-v4-18

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-19/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-19/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../pco-fbc/base
+
+nameSuffix: pco-fbc-v4-19
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-19/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/pco-fbc/overlays/pco-fbc-v4-19/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: pco-fbc-v4-19

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/base/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - releaseplan.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/base/releaseplan.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/base/releaseplan.yaml
@@ -7,7 +7,7 @@ metadata:
   name: promote-to-candidate-
   namespace: rhtas-tenant
 spec:
-  application: policy-controller
+  application: application
   tenantPipeline:
     params:
     - name: git-url
@@ -15,6 +15,16 @@ spec:
     - name: code-freeze
       value: "false"
     - name: type
-      value: "component"
+      value: "operator"
     - name: file-name
-      value: "policy-controller.json"
+      value: "policy-controller-operator.json"
+    serviceAccountName: rhtas-build-bot
+    pipelineRef:
+      resolver: git
+      params:
+        - name: url
+          value: "https://github.com/securesign/pipelines"
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: "pipelines/promote-to-candidate.yaml"

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/overlays/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/overlays/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - policy-controller-operator

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/overlays/policy-controller-operator/kustomization.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/overlays/policy-controller-operator/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../policy-controller-operator/base
+
+nameSuffix: policy-controller-operator
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/overlays/policy-controller-operator/patch.yaml
+++ b/konflux-configs/releasePlans/promoteToCandidateRPs/policy-controller-operator/overlays/policy-controller-operator/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: promote-to-candidate-
+  namespace: rhtas-tenant
+spec:
+  application: policy-controller-operator


### PR DESCRIPTION
## Summary by Sourcery

Set up promote-to-candidate release plans for the policy-controller component, its operator, and a fbc variant with version-specific kustomize overlays to streamline promotions across OpenShift releases

New Features:
- Add base ReleasePlan for policy-controller-operator with tenantPipeline and pipelineRef settings for candidate promotion
- Add base ReleasePlan for pco-fbc with tenantPipeline parameters for candidate promotion
- Extend the policy-controller component overlay with tenantPipeline parameters for candidate promotion

Enhancements:
- Add kustomization overlays for pco-fbc for OpenShift versions 4.14 through 4.19 referencing the base release plan
- Add kustomization overlays for policy-controller-operator
- Add aggregate kustomization to include all pco-fbc version overlays