### PR TITLE
Adding Universal Labels to build pipelines

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -174,6 +174,15 @@ spec:
       - "release=$SOURCE_DATE_EPOCH"
     - name: source-date-epoch
       value: '$(tasks.clone-repository.results.commit-timestamp)'
+    - name: version
+      value:
+      - "version=1.3.0"
+    - name: vendor
+      value:
+      - "vendor=Red Hat, Inc"
+    - name: maintainer
+      value:
+      - "maintainer=Red Hat, Inc"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -175,6 +175,15 @@ spec:
       - "release=$SOURCE_DATE_EPOCH"
     - name: source-date-epoch
       value: '$(tasks.clone-repository.results.commit-timestamp)'
+    - name: version
+      value:
+      - "version=1.3.0"
+    - name: vendor
+      value:
+      - "vendor=Red Hat, Inc"
+    - name: maintainer
+      value:
+      - "maintainer=Red Hat, Inc"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -191,6 +191,9 @@ spec:
     - name: release
       value:
       - "release=1.3.0"
+    - name: maintainer
+      value:
+      - "maintainer=Red Hat, Inc"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -182,6 +182,15 @@ spec:
       - "release=$SOURCE_DATE_EPOCH"
     - name: source-date-epoch
       value: '$(tasks.clone-repository.results.commit-timestamp)'
+    - name: version
+      value:
+      - "version=1.3.0"
+    - name: vendor
+      value:
+      - "vendor=Red Hat, Inc"
+    - name: release
+      value:
+      - "release=1.3.0"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -197,6 +197,15 @@ spec:
       - "release=$SOURCE_DATE_EPOCH"
     - name: source-date-epoch
       value: '$(tasks.clone-repository.results.commit-timestamp)'
+    - name: version
+      value:
+      - "version=1.3.0"
+    - name: vendor
+      value:
+      - "vendor=Red Hat, Inc"
+    - name: maintainer
+      value:
+      - "maintainer=Red Hat, Inc"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/fbc-builder.yaml
+++ b/pipelines/fbc-builder.yaml
@@ -162,6 +162,33 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: generate-labels
+    params:
+    - name: label-templates
+      value:
+      - "release=$SOURCE_DATE_EPOCH"
+    - name: source-date-epoch
+      value: '$(tasks.clone-repository.results.commit-timestamp)'
+    - name: version
+      value:
+      - "version=1.3.0"
+    - name: vendor
+      value:
+      - "vendor=Red Hat, Inc"
+    - name: maintainer
+      value:
+      - "maintainer=Red Hat, Inc"
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: generate-labels
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:7d3895b11c66998c5c7c0deac168c514114e990cbb2fcda8d3dfb1dbd3440c60
+      - name: kind
+        value: task
+      resolver: bundles  
   - matrix:
       params:
       - name: PLATFORM
@@ -194,6 +221,10 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
+    - name: LABELS
+      value:
+      - $(tasks.generate-labels.results.labels[*])
+      - "short-commit=$(tasks.clone-repository.results.short-commit)"
     runAfter:
     - clone-repository
     taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Add standardized container metadata labels to Tekton build pipelines

Enhancements:
- Insert version, vendor, and maintainer labels into bundle-build-oci-ta, docker-build-multi-platform-oci-ta, docker-build-oci-ta, and docker-build pipelines
- Apply a static release label of 1.3.0 in the docker-build-oci-ta pipeline