### PR TITLE
SECURESIGN-2743 Add rekor-monitor to mirrors

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -129,6 +129,9 @@ spec:
                   - source: registry.redhat.io/rhtas/rekor-backfill-redis-rhel9
                     mirrors:
                     - quay.io/securesign/rekor-backfill-redis
+                  - source: registry.redhat.io/rhtas/rekor-monitor-rhel9
+                    mirrors:
+                    - quay.io/securesign/rekor-monitor
                   - source: registry.redhat.io/rhtas/tuf-server-rhel9
                     mirrors:
                     - quay.io/securesign/scaffold-tuf-server


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Include quay.io/securesign/rekor-monitor as a mirror for registry.redhat.io/rhtas/rekor-monitor-rhel9