### PR TITLE
fix: add registry creds

### DIFF
--- a/konflux-configs/serviceAccounts/its-gate-sa.yaml
+++ b/konflux-configs/serviceAccounts/its-gate-sa.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhtas-its-gate
+  namespace: rhtas-tenant
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rhtas-its-gate-role
+  namespace: rhtas-tenant
+rules:
+  - apiGroups: ["appstudio.redhat.com"]
+    resources: ["snapshots"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhtas-its-gate-rolebinding
+  namespace: rhtas-tenant
+subjects:
+  - kind: ServiceAccount
+    name: rhtas-its-gate
+    namespace: rhtas-tenant
+roleRef:
+  kind: Role
+  name: rhtas-its-gate-role
+  apiGroup: rbac.authorization.k8s.io

--- a/konflux-configs/serviceAccounts/rhtas-installer.yaml
+++ b/konflux-configs/serviceAccounts/rhtas-installer.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhtas-installer
+  namespace: rhtas-tenant
+secrets:
+  - name: registry-redhat-io-pull-secret
+imagePullSecrets:
+  - name: registry-redhat-io-pull-secret

--- a/pipelines/policy-controller-operator-e2e.yaml
+++ b/pipelines/policy-controller-operator-e2e.yaml
@@ -136,6 +136,7 @@ spec:
             value: main
           - name: pathInRepo
             value: tasks/install-operator-from-bundle.yaml
+      serviceAccountName: rhtas-installer
       params:
         - name: eaasSpaceSecretRef
           value: $(tasks.provision-eaas-space.results.secretRef)


### PR DESCRIPTION
## Summary by Sourcery

Add new service accounts with necessary RBAC roles and registry credentials, and update the e2e pipeline to leverage the installer account

New Features:
- Introduce a service account 'rhtas-its-gate' with a Role and RoleBinding to grant snapshot get/list/watch permissions
- Introduce a service account 'rhtas-installer' with an attached imagePullSecret for registry.redhat.io

Enhancements:
- Configure the policy-controller-operator-e2e pipeline to use the 'rhtas-installer' service account