### PR TITLE
Adding Universal CPE label to container builds

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -183,6 +183,9 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
+    - name:
+      value:
+      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -184,6 +184,9 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
+    - name:
+      value:
+      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -194,6 +194,9 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
+    - name:
+      value:
+      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -206,6 +206,9 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
+    - name:
+      value:
+      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Insert cpe=\"cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9\" label after the maintainer label in bundle-build-oci-ta, docker-build-multi-platform-oci-ta, docker-build-oci-ta, and docker-build pipeline files