### PR TITLE
ci: increase limits

### DIFF
--- a/pipelines/policy-controller-operator-e2e.yaml
+++ b/pipelines/policy-controller-operator-e2e.yaml
@@ -427,6 +427,13 @@ spec:
                 value: "$(params.TAS_E2E_NAMESPACE)"
               - name: POLICY_CONTROLLER_OPERATOR_NS
                 value: "$(params.POLICY_CONTROLLER_OPERATOR_NS)"
+            computeResources:
+              requests:
+                cpu: "1500m"
+                memory: "3Gi"
+              limits:
+                cpu: "3"
+                memory: "6Gi"
             volumeMounts:
               - name: repository
                 mountPath: /repository


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure CPU requests (1500m) and limits (3) and memory requests (3Gi) and limits (6Gi) for the policy-controller-operator-e2e Task in CI