### PR TITLE
Adding memory limits for e2e test

### DIFF
--- a/pipelines/rhtas-operator-e2e.yaml
+++ b/pipelines/rhtas-operator-e2e.yaml
@@ -622,6 +622,12 @@ spec:
               ./tas-env-variables.sh > .env
           - name: execute-tas-e2e
             image: registry.redhat.io/ubi9/go-toolset:1.24@sha256:14c369670cf3473d8e9b93e42d120c01b79a6f13884c396a1c89b7ca46f859b7
+            computeResources:
+              limits:
+                memory: 8Gi
+              requests:
+                memory: 2Gi
+                cpu: '1'
             volumeMounts:
               - name: credentials
                 mountPath: /credentials


### PR DESCRIPTION
Tests too often fail with "step-execute-tas-e2e" exited with code 1: OOMKilled