### PR TITLE
Updated Pipeline Images

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -251,7 +251,7 @@ spec:
       - name: name
         value: buildah-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:203b7a3d8c04c1f3b5327db3f31a19647f8d46304e7ced1dd5dcbba19445ac10
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:fdd3f39c8ea97de0d77bcde160704dbd33fdcb9cd235836927bbb170aaefb80f
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -242,7 +242,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:17a0b093c9e9d21e9e374c60a88eb293a0fa57e4e2b67baf20ccac9735aa20ff
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:a60e433e02bfda6811719690edbf1e924820d107ad658c8a9690498d4c7e9c7b
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -245,7 +245,7 @@ spec:
       - name: name
         value: buildah-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:203b7a3d8c04c1f3b5327db3f31a19647f8d46304e7ced1dd5dcbba19445ac10
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:fdd3f39c8ea97de0d77bcde160704dbd33fdcb9cd235836927bbb170aaefb80f
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Fixes the signature check issue which was blocking release.

## Summary by Sourcery

Update pipeline bundle image digests to resolve signature verification errors

Bug Fixes:
- Fix signature check failures by refreshing sha256 digests

Enhancements:
- Update task-buildah-oci-ta and task-buildah-remote-oci-ta bundle references in bundle-build-oci-ta, docker-build-multi-platform-oci-ta, and docker-build-oci-ta pipelines