### PR TITLE
Moving quotations for CPE label to the left

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -185,7 +185,7 @@ spec:
       - "maintainer=Red Hat, Inc"
     - name:
       value:
-      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
+      - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -186,7 +186,7 @@ spec:
       - "maintainer=Red Hat, Inc"
     - name:
       value:
-      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
+      - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -196,7 +196,7 @@ spec:
       - "maintainer=Red Hat, Inc"
     - name:
       value:
-      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
+      - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -208,7 +208,7 @@ spec:
       - "maintainer=Red Hat, Inc"
     - name:
       value:
-      - cpe="cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
+      - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:
     - clone-repository
     taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Standardize CPE label quoting across multiple pipeline configurations by moving the opening quote so that the entire ‘cpe=…’ string is enclosed

Enhancements:
- Reposition the leading quote for the cpe label in bundle-build-oci-ta.yaml
- Reposition the leading quote for the cpe label in docker-build-multi-platform-oci-ta.yaml
- Reposition the leading quote for the cpe label in docker-build-oci-ta.yaml
- Reposition the leading quote for the cpe label in docker-build.yaml