### PR TITLE
Adding CPE name

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -183,7 +183,7 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
-    - name:
+    - name: cpe
       value:
       - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:

--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -184,7 +184,7 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
-    - name:
+    - name: cpe
       value:
       - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -194,7 +194,7 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
-    - name:
+    - name: cpe
       value:
       - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -206,7 +206,7 @@ spec:
     - name: maintainer
       value:
       - "maintainer=Red Hat, Inc"
-    - name:
+    - name: cpe
       value:
       - "cpe=cpe:/a:redhat:trusted_artifact_signer:1.3.0::el9"
     runAfter:


### PR DESCRIPTION
## Summary by Sourcery

Add a CPE name environment variable to all OCI and Docker build pipelines

Build:
- Include cpe label in bundle-build-oci-ta pipeline
- Include cpe label in docker-build-multi-platform-oci-ta pipeline
- Include cpe label in docker-build-oci-ta pipeline
- Include cpe label in docker-build pipeline