### PR TITLE
Update results name for get manager image

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -209,7 +209,7 @@ spec:
       - name: url
         value: "https://github.com/securesign/pipelines.git"
       - name: revision
-        value: 'db87a7e2042dbc04f455c200aa52d2e0fb69be4b'
+        value: 'bcb1f70b96585ee7d591eeef62a75eeb5a1dea55'
       - name: pathInRepo
         value: tasks/wait-for-pipelinerun.yaml
   - name: build-container
@@ -231,7 +231,7 @@ spec:
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])
-      - 'IMG=$(params.manager-registry-url)@$(tasks.get-manager-image.results.IMAGE_DIGEST)'
+      - 'IMG=$(params.manager-registry-url)@$(tasks.get-manager-image.results.ARTIFACT_DIGEST)'
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: SOURCE_ARTIFACT

--- a/tasks/wait-for-pipelinerun.yaml
+++ b/tasks/wait-for-pipelinerun.yaml
@@ -4,15 +4,15 @@ metadata:
   name: wait-for-pipelinerun
 spec:
   description: >
-    Waits for a Tekton PipelineRun matching the specified selector to complete, then extracts the produced image URL and digest from its results.
+    Waits for a Tekton PipelineRun matching the specified selector to complete, then extracts the produced artifact reference and digest from its results.
   params:
     - name: selector
       description: Label selector used to find the target PipelineRuns (e.g., "mylabel=myvalue").
   results:
-    - description: The canonical URL of the found image, typically excluding the tag or digest (e.g., quay.io/namespace/repository).
-      name: IMAGE_URL
-    - description: The SHA256 digest of the image's manifest.
-      name: IMAGE_DIGEST
+    - description: Identifier for the produced artifact (for example, a repository or storage location).
+      name: ARTIFACT_REFERENCE
+    - description: The SHA256 digest reported for the produced artifact.
+      name: ARTIFACT_DIGEST
   steps:
     - name: wait-for-pipelinerun
       image: quay.io/konflux-ci/konflux-test:latest@sha256:d596724343a31c201a5c2e79f233f9ef78ac65726ae4ed5ffa41d76b3dac630f
@@ -41,8 +41,8 @@ spec:
           fi
         }
           
-        image_url=""
-        image_digest=""
+        artifact_reference=""
+        artifact_digest=""
         
         echo "Search PipelineRuns with selector '$SELECTOR'"
         pipeline_names_output=$(oc get pipelineruns -l "$SELECTOR" --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[*].metadata.name}' --ignore-not-found)
@@ -62,23 +62,23 @@ spec:
         succeeded_condition_json=$(echo "$pr_status_json" | jq -r '.conditions[]? | select(.type=="Succeeded") | .status')
         
         if [ "$succeeded_condition_json" == "True" ]; then
-          image_url=$(echo "$pr_status_json" | jq -r '.results[]? | select(.name=="IMAGE_URL") | .value')
-          image_digest=$(echo "$pr_status_json" | jq -r '.results[]? | select(.name=="IMAGE_DIGEST") | .value')
-          echo "Image found in $pr_name, IMAGE_URL: $image_url, IMAGE_DIGEST: $image_digest"
+          artifact_reference=$(echo "$pr_status_json" | jq -r '.results[]? | select(.name=="IMAGE_URL") | .value')
+          artifact_digest=$(echo "$pr_status_json" | jq -r '.results[]? | select(.name=="IMAGE_DIGEST") | .value')
+          echo "Artifact found in $pr_name, ARTIFACT_REFERENCE: $artifact_reference, ARTIFACT_DIGEST: $artifact_digest"
         else
           echo "PipelineRun $pr_name 'Succeeded' condition is 'False'" >&2
           exit 1
         fi
           
-        if [[ -z "$image_digest" ]]; then
-          echo "image_digest: not found" >&2
+        if [[ -z "$artifact_digest" ]]; then
+          echo "artifact_digest: not found" >&2
           exit 1
         fi
           
-        if [[ -z "$image_url" ]]; then
-          echo "image_url: not found" >&2
+        if [[ -z "$artifact_reference" ]]; then
+          echo "artifact_reference: not found" >&2
           exit 1
         fi
         
-        printf "%s" "$image_digest" | tee $(results.IMAGE_DIGEST.path)
-        printf "%s" "$image_url" | tee $(results.IMAGE_URL.path)
+        printf "%s" "$artifact_digest" | tee $(results.ARTIFACT_DIGEST.path)
+        printf "%s" "$artifact_reference" | tee $(results.ARTIFACT_REFERENCE.path)


### PR DESCRIPTION
## Summary by Sourcery

Consolidate task outputs under consistent artifact terminology by renaming image-related result fields to artifact_reference and artifact_digest, and update pipeline references and revision accordingly

Enhancements:
- Rename IMAGE_URL and IMAGE_DIGEST results, variables, and descriptions in the wait-for-pipelinerun task to ARTIFACT_REFERENCE and ARTIFACT_DIGEST
- Update bundle-build-oci-ta pipeline to reference ARTIFACT_DIGEST in BUILD_ARGS

Chores:
- Bump the git revision for the wait-for-pipelinerun task in pipeline configuration