### PR TITLE
Updating Unit test go version

### DIFF
--- a/tasks/go-unit-test-oci-ta.yaml
+++ b/tasks/go-unit-test-oci-ta.yaml
@@ -21,7 +21,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: GO_BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
+      default: registry.redhat.io/ubi9/go-toolset:9.6@sha256:84286c7555df503df0bd3acb86fe2ad50af82a07f35707918bb0fad312fdc193
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir

--- a/tasks/go-unit-test.yaml
+++ b/tasks/go-unit-test.yaml
@@ -15,7 +15,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: GO_BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
+      default: registry.redhat.io/ubi9/go-toolset:9.6@sha256:84286c7555df503df0bd3acb86fe2ad50af82a07f35707918bb0fad312fdc193
   steps:
     - name: run-tests
       image:  $(params.GO_BASE_IMAGE)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump default GO_BASE_IMAGE from go-toolset:1.24 to go-toolset:9.6 in go-unit-test and go-unit-test-oci-ta tasks