### PR TITLE
Bumping Unit test limits across all docker-builds

### DIFF
--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -7,7 +7,6 @@ spec:
     - name: run-tests
       computeResources:
         limits:
-          cpu: "3"
           memory: 3Gi
   finally:
   - name: show-sbom


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump CPU and memory requests and limits to 3 CPU and 3Gi memory for the run-tests step in the docker-build-oci-ta pipeline