### PR TITLE
Removing steps ffrom build pipeline

### DIFF
--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -3,11 +3,6 @@ kind: Pipeline
 metadata:
   name: docker-build-oci-ta
 spec:
-  steps:
-    - name: run-tests
-      computeResources:
-        limits:
-          memory: 3Gi
   finally:
   - name: show-sbom
     params:


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove the steps block with run-tests and its memory limits in the build pipeline YAML