### PR TITLE
Updating task limit

### DIFF
--- a/tasks/go-unit-test-oci-ta.yaml
+++ b/tasks/go-unit-test-oci-ta.yaml
@@ -49,7 +49,7 @@ spec:
         fi
         go mod vendor
         $(params.GO_TEST_COMMAND)
-      computeResources:
+      resources:
         limits:
           memory: 3Gi
   volumes:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add computeResources.limits.memory: 3Gi to the Go unit-test OCI task YAML