### PR TITLE
Release process dependency repaired

### DIFF
--- a/pipelines/release.yaml
+++ b/pipelines/release.yaml
@@ -101,7 +101,7 @@ spec:
             - ""
     - name: process-releases
       runAfter:
-        - clone-repository
+        - parse-release-config
       params:
         - name: component-release-dir
           value: "$(tasks.parse-release-config.results.componentReleaseDirectory)"


### PR DESCRIPTION
Wrong dependency repaired - need to wait for the parse-release-config step to use its values.