### PR TITLE
update conforma cli stack

### DIFF
--- a/konflux-configs/base/project/overlay/cli-stacks/patch/conforma-cli-stack.yaml
+++ b/konflux-configs/base/project/overlay/cli-stacks/patch/conforma-cli-stack.yaml
@@ -15,9 +15,9 @@
       componentName: "conforma-cli-stack"
       source:
         git:
-          url: https://github.com/conforma/cli
-          revision: "release-v0.8"
-          dockerfileUrl: Dockerfile.cli-stack.rh
+          url: https://github.com/securesign/cosign
+          revision: "{{.branch}}"
+          dockerfileUrl: Dockerfile.conforma-cli-stack.rh
 - op: add
   path: /spec/resources/-
   value:


### PR DESCRIPTION
The conforma cli repository is already registered with rhtap namespace and cross registering the cli-stack on the same repository  under a different namespace is not possible. 
Therefore, onboarding the cli distribution for conforma to cosign repo