### PR TITLE
chore: Updating Go images for pipelines

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -115,7 +115,7 @@ spec:
   - description: The Go base image used to run the unit tests
     name: go_base_image
     type: string
-    default: registry.redhat.io/ubi9/go-toolset:9.7@sha256:71101fd9ba32aabeaec2c073e5786c91642aaee902475fce3d8280457fb19e9d
+    default: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
   - name: enable-package-registry-proxy
     default: 'true'
     description: Use the package registry proxy when prefetching dependencies

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -82,7 +82,7 @@ spec:
   - description: The Go base image used to run the unit tests
     name: go_base_image
     type: string
-    default: registry.redhat.io/ubi9/go-toolset:9.7@sha256:71101fd9ba32aabeaec2c073e5786c91642aaee902475fce3d8280457fb19e9d
+    default: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
   - name: buildah-format
     default: docker
     type: string

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -100,7 +100,7 @@ spec:
   - description: The Go base image used to run the unit tests
     name: go_base_image
     type: string
-    default: registry.redhat.io/ubi9/go-toolset:9.7@sha256:71101fd9ba32aabeaec2c073e5786c91642aaee902475fce3d8280457fb19e9d
+    default: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
   - name: buildah-format
     default: docker
     type: string

--- a/pipelines/integration-test/operator-upgrade.yaml
+++ b/pipelines/integration-test/operator-upgrade.yaml
@@ -309,7 +309,7 @@ spec:
                   value: credentials
             - name: execute-test
               onError: continue
-              image: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2e6eebc0987783db7fa8274b3bb3f164228e7763205bfb8fd3ecc342f7033326
+              image: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
               results:
                 - name: exit-code
               env:

--- a/pipelines/integration-test/pco-operator-upgrade.yaml
+++ b/pipelines/integration-test/pco-operator-upgrade.yaml
@@ -323,7 +323,7 @@ spec:
                   value: credentials
             - name: execute-test
               onError: continue
-              image: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2e6eebc0987783db7fa8274b3bb3f164228e7763205bfb8fd3ecc342f7033326
+              image: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
               results:
                 - name: exit-code
               env:

--- a/pipelines/integration-test/policy-controller-fbc-e2e.yaml
+++ b/pipelines/integration-test/policy-controller-fbc-e2e.yaml
@@ -353,7 +353,7 @@ spec:
                 - name: credentials
                   value: credentials
             - name: execute-operator-e2e
-              image: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2e6eebc0987783db7fa8274b3bb3f164228e7763205bfb8fd3ecc342f7033326
+              image: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
               env:
                 - name: OIDC_HOST
                   value: "$(tasks.prepare-tests.results.oidc-hostname)"

--- a/pipelines/integration-test/policy-controller-operator-e2e.yaml
+++ b/pipelines/integration-test/policy-controller-operator-e2e.yaml
@@ -340,7 +340,7 @@ spec:
                 - name: credentials
                   value: credentials
             - name: execute-operator-e2e
-              image: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2e6eebc0987783db7fa8274b3bb3f164228e7763205bfb8fd3ecc342f7033326
+              image: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
               env:
                 - name: OIDC_HOST
                   value: "$(tasks.prepare-tests.results.oidc-hostname)"

--- a/tasks/go-unit-test-oci-ta.yaml
+++ b/tasks/go-unit-test-oci-ta.yaml
@@ -21,7 +21,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: GO_BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2bb1fe3e239c0085cdaac1de3d50b44fcdc12ccc8360c8e49eeaeca09a5a072c
+      default: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir

--- a/tasks/go-unit-test.yaml
+++ b/tasks/go-unit-test.yaml
@@ -15,7 +15,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: GO_BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2bb1fe3e239c0085cdaac1de3d50b44fcdc12ccc8360c8e49eeaeca09a5a072c
+      default: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
   steps:
     - name: run-tests
       image:  $(params.GO_BASE_IMAGE)

--- a/tasks/integration-test/ansible/run-sigstore-e2e-tests.yaml
+++ b/tasks/integration-test/ansible/run-sigstore-e2e-tests.yaml
@@ -45,7 +45,7 @@ spec:
         buildah tag alpine:latest $IMAGE
         buildah push $IMAGE
     - name: execute-tas-e2e
-      image: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2e6eebc0987783db7fa8274b3bb3f164228e7763205bfb8fd3ecc342f7033326
+      image: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
       workingDir: $(workspaces.source-code.path)/sigstore-e2e
       computeResources:
         limits:

--- a/tasks/integration-test/operator-e2e.yaml
+++ b/tasks/integration-test/operator-e2e.yaml
@@ -47,7 +47,7 @@ spec:
           value: credentials
     - name: execute-operator-e2e
       onError: continue
-      image: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2e6eebc0987783db7fa8274b3bb3f164228e7763205bfb8fd3ecc342f7033326
+      image: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
       results:
         - name: exit-code
       env:

--- a/tasks/integration-test/sigstore-e2e.yaml
+++ b/tasks/integration-test/sigstore-e2e.yaml
@@ -101,7 +101,7 @@ spec:
         oc project $TASNAMESPACE
         ./tas-env-variables.sh > .env
     - name: execute-tas-e2e
-      image: registry.redhat.io/ubi9/go-toolset:9.7@sha256:2e6eebc0987783db7fa8274b3bb3f164228e7763205bfb8fd3ecc342f7033326
+      image: registry.redhat.io/ubi9/go-toolset@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999
       results:
         - name: exit-code
       volumeMounts:


### PR DESCRIPTION
Newest Go Version is 1.25.9 , this updates images to that point.