### PR TITLE
fix: install playwright before creating vendor

### DIFF
--- a/tasks/integration-test/sigstore-e2e.yaml
+++ b/tasks/integration-test/sigstore-e2e.yaml
@@ -138,8 +138,8 @@ spec:
         echo "Run tests"
         mkdir -p $(workspaces.source-code.path)/dump/sigstore-e2e
         set -o allexport && source ./.env && set +o allexport
-        go mod vendor
         go run github.com/playwright-community/playwright-go/cmd/playwright install --with-deps
+        go mod vendor
         # exclude benchmark tests
         go test -v $(go list ./test/... | grep -v benchmark) --ginkgo.v -json \
         > $(workspaces.source-code.path)/dump/sigstore-e2e/test-result.json


### PR DESCRIPTION
```
+ go run github.com/playwright-community/playwright-go/cmd/playwright install --with-deps
cannot find module providing package github.com/playwright-community/playwright-go/cmd/playwright: import lookup disabled by -mod=vendor
	(Go version in go.mod is at least 1.14 and vendor directory exists.)
```