### PR TITLE
fix: increase timeout for additional test cases

### DIFF
--- a/tasks/integration-test/operator-e2e.yaml
+++ b/tasks/integration-test/operator-e2e.yaml
@@ -94,7 +94,7 @@ spec:
         fi
 
 
-        go test -p 1 ./test/e2e/... -tags="$TAGS" -timeout 30m -json > $(workspaces.source-code.path)/dump/operator-e2e/test-result.json
+        go test -p 1 ./test/e2e/... -tags="$TAGS" -timeout 60m -json > $(workspaces.source-code.path)/dump/operator-e2e/test-result.json
         status=$?
         printf "%s" "$status" > "$(step.results.exit-code.path)"
 


### PR DESCRIPTION
Need increased timeout to test additional PCKS e2e test cases.
Upon running them on a local cluster, all the tests take about 53 mins approx.