### PR TITLE
fix: gstreamer1: install failed

### DIFF
--- a/tasks/integration-test/sigstore-e2e.yaml
+++ b/tasks/integration-test/sigstore-e2e.yaml
@@ -143,7 +143,7 @@ spec:
         # On RHEL/UBI9 we install Chromium's system dependencies manually via dnf.
         # Mapped from the ubuntu20.04 chromium list (Playwright's fallback for unsupported OS):
         # https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/nativeDeps.ts#L37-L63
-        dnf install -y \
+        dnf install -y --setopt=install_weak_deps=False \
           alsa-lib atk at-spi2-atk at-spi2-core cairo cups-libs \
           dbus-libs glib2 gtk3 libdrm libglvnd-egl libX11 libX11-xcb \
           libxcb libXcomposite libXdamage libXext libXfixes libxkbcommon \


### PR DESCRIPTION
Fixing:
```
 Installing       : gstreamer1-1.22.12-3.el9.x86_64                      30/81Error unpacking rpm package gstreamer1-1.22.12-3.el9.x86_64
 
  Installing       : alsa-lib-1.2.14-1.el9.x86_64                         31/81 
error: unpacking of archive failed on file /usr/libexec/gstreamer-1.0/gst-ptp-helper;69fe097d: cpio: cap_set_file failed - Operation not permitted
error: gstreamer1-1.22.12-3.el9.x86_64: install failed
```