### PR TITLE
Updating Ansible Test Commands

### DIFF
--- a/pipelines/integration-test/ansible-upgrade.yaml
+++ b/pipelines/integration-test/ansible-upgrade.yaml
@@ -168,8 +168,8 @@ spec:
                 export TAS_SINGLE_NODE_REGISTRY_PASSWORD=$(cat /rhio-creds/rhio-password)
                 set -x
                 
-                python3.11 -m pip install --upgrade pip
-                python3.11 -m pip install -r $(workspaces.work.path)/ansible/testing-requirements.txt
+                python3.12 -m pip install --upgrade pip
+                python3.12 -m pip install -r $(workspaces.work.path)/ansible/testing-requirements.txt
         
                 ansible-galaxy install -r  $(workspaces.work.path)/ansible/molecule/requirements.yml
                 

--- a/tasks/integration-test/ansible/run-molecule-tests.yaml
+++ b/tasks/integration-test/ansible/run-molecule-tests.yaml
@@ -90,11 +90,11 @@ spec:
         export TAS_SINGLE_NODE_REGISTRY_PASSWORD=$(cat /work/rhio-password)
         set -x
         
-        python3.11 -m venv /work/venv
+        python3.12 -m venv /work/venv
         source /work/venv/bin/activate
         
-        python3.11 -m pip install --upgrade pip
-        python3.11 -m pip install -r $(workspaces.sources.path)/artifact-signer-ansible/testing-requirements.txt
+        python3.12 -m pip install --upgrade pip
+        python3.12 -m pip install -r $(workspaces.sources.path)/artifact-signer-ansible/testing-requirements.txt
 
         ansible-galaxy install -r  $(workspaces.sources.path)/artifact-signer-ansible/molecule/requirements.yml
         ansible-galaxy collection install $(workspaces.sources.path)/releases/redhat-artifact_signer-*.tar.gz --force


### PR DESCRIPTION
Ansible dev tools images have updated to python 3.12. This will fix all tests in ansible repo. I believe.