### PR TITLE
feat: upload E2E coverage to Codecov for policy-controller-operator

### DIFF
--- a/pipelines/integration-test/policy-controller-fbc-e2e.yaml
+++ b/pipelines/integration-test/policy-controller-fbc-e2e.yaml
@@ -373,6 +373,11 @@ spec:
                   value: "$(params.TAS_DEPLOY_NAMESPACE)"
                 - name: POLICY_CONTROLLER_OPERATOR_NS
                   value: "$(params.POLICY_CONTROLLER_OPERATOR_NS)"
+                - name: CODECOV_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: codecov-token
+                      key: token
               computeResources:
                 requests:
                   cpu: "1500m"
@@ -399,7 +404,25 @@ spec:
                 go mod vendor
                 make e2e-test
                 status=$?
-                
+
+                if [ -f e2e-coverage.out ]; then
+                  echo "Uploading E2E coverage to Codecov..."
+                  COMMIT_SHA=$(git rev-parse HEAD)
+                  curl -Os https://cli.codecov.io/latest/linux/codecov
+                  chmod +x codecov
+                  ./codecov --verbose do-upload \
+                    -t "$CODECOV_TOKEN" \
+                    --git-service github \
+                    --slug "securesign/policy-controller-operator" \
+                    -C "$COMMIT_SHA" \
+                    -F e2e-tests \
+                    -f e2e-coverage.out \
+                    || echo "WARNING: Codecov upload failed (non-fatal)"
+                  rm -f codecov
+                else
+                  echo "WARNING: e2e-coverage.out not found, skipping Codecov upload"
+                fi
+
                 if [[ $status -ne 0 ]]; then
                   pods=$(oc get pods -n "$POLICY_CONTROLLER_OPERATOR_NS" -o jsonpath='{.items[*].metadata.name}')
                   for pod in $pods; do

--- a/pipelines/integration-test/policy-controller-operator-e2e.yaml
+++ b/pipelines/integration-test/policy-controller-operator-e2e.yaml
@@ -360,6 +360,11 @@ spec:
                   value: "$(params.TAS_DEPLOY_NAMESPACE)"
                 - name: POLICY_CONTROLLER_OPERATOR_NS
                   value: "$(params.POLICY_CONTROLLER_OPERATOR_NS)"
+                - name: CODECOV_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: codecov-token
+                      key: token
               computeResources:
                 requests:
                   cpu: "1500m"
@@ -386,7 +391,25 @@ spec:
                 go mod vendor
                 make e2e-test
                 status=$?
-                
+
+                if [ -f e2e-coverage.out ]; then
+                  echo "Uploading E2E coverage to Codecov..."
+                  COMMIT_SHA=$(git rev-parse HEAD)
+                  curl -Os https://cli.codecov.io/latest/linux/codecov
+                  chmod +x codecov
+                  ./codecov --verbose do-upload \
+                    -t "$CODECOV_TOKEN" \
+                    --git-service github \
+                    --slug "securesign/policy-controller-operator" \
+                    -C "$COMMIT_SHA" \
+                    -F e2e-tests \
+                    -f e2e-coverage.out \
+                    || echo "WARNING: Codecov upload failed (non-fatal)"
+                  rm -f codecov
+                else
+                  echo "WARNING: e2e-coverage.out not found, skipping Codecov upload"
+                fi
+
                 if [[ $status -ne 0 ]]; then
                   pods=$(oc get pods -n "$POLICY_CONTROLLER_OPERATOR_NS" -o jsonpath='{.items[*].metadata.name}')
                   for pod in $pods; do


### PR DESCRIPTION
## Summary

- Add Codecov CLI upload of `e2e-coverage.out` to the `execute-operator-e2e` step in both the bundle (`policy-controller-operator-e2e.yaml`) and FBC (`policy-controller-fbc-e2e.yaml`) integration test pipelines.
- Inject `CODECOV_TOKEN` via `secretKeyRef` from the `codecov-token` Kubernetes secret.
- Upload is non-fatal — a Codecov outage will never block test results.

## Prerequisites

A `codecov-token` secret must be created in the Konflux tenant namespace before merging:
```bash
kubectl create secret generic codecov-token \
  --from-literal=token=<CODECOV_UPLOAD_TOKEN> \
  -n <konflux-tenant-namespace>
```

## Test plan

- [ ] Verify `codecov-token` secret exists in the Konflux namespace
- [ ] Trigger a policy-controller-operator build and confirm the bundle E2E pipeline uploads coverage
- [ ] Trigger an FBC build and confirm the FBC E2E pipeline uploads coverage
- [ ] Verify coverage appears in Codecov under the `e2e-tests` flag
- [ ] Verify pipeline still passes when Codecov upload fails (e.g. bad token)

Ref: SECURESIGN-4443

🤖 Generated with [Claude Code](https://claude.com/claude-code)