### PR TITLE
chore: limit FIPS e2e tests to v4.19 only

### DIFF
--- a/konflux-configs/base/project/base/ocp/rhtas/v4.16/patch.yaml
+++ b/konflux-configs/base/project/base/ocp/rhtas/v4.16/patch.yaml
@@ -65,7 +65,7 @@
       application: "{{.application}}{{.nameSuffix}}"
       contexts:
         - description: execute the integration test when component {{.application}}{{.nameSuffix}}-v4-16 updates
-          name: "component_{{.application}}{{.nameSuffix}}-v4-16"
+          name: "disabled"
       params:
         - name: OCP_VERSION
           value: "4.16"

--- a/konflux-configs/base/project/base/ocp/rhtas/v4.17/patch.yaml
+++ b/konflux-configs/base/project/base/ocp/rhtas/v4.17/patch.yaml
@@ -65,7 +65,7 @@
       application: "{{.application}}{{.nameSuffix}}"
       contexts:
         - description: execute the integration test when component {{.application}}{{.nameSuffix}}-v4-17 updates
-          name: "component_{{.application}}{{.nameSuffix}}-v4-17"
+          name: "disabled"
       params:
         - name: OCP_VERSION
           value: "4.17"

--- a/konflux-configs/base/project/base/ocp/rhtas/v4.18/patch.yaml
+++ b/konflux-configs/base/project/base/ocp/rhtas/v4.18/patch.yaml
@@ -65,7 +65,7 @@
       application: "{{.application}}{{.nameSuffix}}"
       contexts:
         - description: execute the integration test when component {{.application}}{{.nameSuffix}}-v4-18 updates
-          name: "component_{{.application}}{{.nameSuffix}}-v4-18"
+          name: "disabled"
       params:
         - name: OCP_VERSION
           value: "4.18"

--- a/konflux-configs/base/project/base/ocp/rhtas/v4.20/patch.yaml
+++ b/konflux-configs/base/project/base/ocp/rhtas/v4.20/patch.yaml
@@ -65,7 +65,7 @@
       application: "{{.application}}{{.nameSuffix}}"
       contexts:
         - description: execute the integration test when component {{.application}}{{.nameSuffix}}-v4-20 updates
-          name: "component_{{.application}}{{.nameSuffix}}-v4-20"
+          name: "disabled"
       params:
         - name: OCP_VERSION
           value: "4.20"


### PR DESCRIPTION
## Summary
Disable FIPS integration tests on OCP v4.16, v4.17, v4.18, and v4.20, keeping only v4.19 active to reduce resource utilization by 80%.

## Rationale
- FIPS behavior is consistent across OCP versions (certified at platform level)
- v4.19 selected as it's the newest stable version with DAST coverage
- Standard e2e tests remain active on all versions for version-specific issue detection

## Impact
- Resource reduction: 80% fewer FIPS test executions (5 versions → 1 version)
- Test coverage: Maintained via v4.19 FIPS tests + standard e2e on all versions

## Test Plan
- [x] Kustomize build validation passed
- [ ] Monitor v4.19 FIPS test execution after merge
- [ ] Verify no FIPS tests run on v4.16, v4.17, v4.18, v4.20

🤖 Generated with Claude Code