### PR TITLE
chore: New Task to allow for centralisation of release-version tags

### DIFF
--- a/konflux-configs/base/config/kustomization.yaml
+++ b/konflux-configs/base/config/kustomization.yaml
@@ -9,3 +9,9 @@ configMapGenerator:
     literals:
       - automerge="true"
       - platformAutomerge="true"
+
+  # Release version mappings for repo+branch
+  # Versions are defined in rhtas-versions.properties
+  - name: rhtas-repo-branch-versions
+    envs:
+      - rhtas-versions.properties

--- a/konflux-configs/base/config/rhtas-versions.properties
+++ b/konflux-configs/base/config/rhtas-versions.properties
@@ -109,12 +109,12 @@ segment-backup-job__release-1.3=1.3.5
 # ============================================================================
 
 # === Policy Controller ===
-policy-controller__main=1.5.0-dev
-policy-controller__release-1.0=1.0.1
+policy-controller__main=1.5.0
+policy-controller__release-1.0=1.4.2
 
 # === Policy Controller Operator ===
-policy-controller-operator__main=1.1.0
-policy-controller-operator__release-1.0=1.0.1
+policy-controller-operator__main=1.5.0
+policy-controller-operator__release-1.0=1.4.2
 
 # ============================================================================
 # REPO-ONLY FALLBACKS

--- a/konflux-configs/base/config/rhtas-versions.properties
+++ b/konflux-configs/base/config/rhtas-versions.properties
@@ -1,0 +1,144 @@
+# RHTAS Release Version Mappings
+# Format: <repo-name>__<branch-name>=<version>
+# Double underscore (__) separates repo from branch
+
+# ============================================================================
+# RHTAS OPERATOR CORE COMPONENTS
+# These components are deployed and managed by the RHTAS operator
+# ============================================================================
+
+
+# === Fulcio ===
+fulcio__main=1.5.0
+fulcio__release-1.4=1.4.2
+fulcio__release-1.3=1.3.5
+
+# === Rekor ===
+rekor__main=1.5.0
+rekor__release-1.4=1.4.2
+rekor__release-1.3=1.3.5
+
+# === Timestamp Server ===
+timestamp-authority__main=1.5.0
+timestamp-authority__release-1.4=1.4.2
+timestamp-authority__release-1.3=1.3.5
+
+# === TUF Server ===
+tuf-server__main=1.5.0
+tuf-server__release-1.4=1.4.2
+tuf-server__release-1.3=1.3.5
+
+# === Trillian ===
+trillian__main=1.5.0
+trillian__release-1.4=1.4.2
+trillian__release-1.3=1.3.5
+
+# === RHTAS Operator (the operator itself) ===
+secure-sign-operator__main=1.5.0
+secure-sign-operator__release-1.4=1.4.2
+secure-sign-operator__release-1.3=1.3.5
+
+# === RHTAS Console ===
+rhtas-console__main=1.5.0
+rhtas-console__release-1.4=1.4.2
+rhtas-console__release-1.3=1.3.5
+
+# === RHTAS Console UI ===
+rhtas-console-ui__main=1.5.0
+rhtas-console-ui__release-1.4=1.4.2
+rhtas-console-ui__release-1.3=1.3.5
+
+# === Cosign ===
+cosign__main=1.5.0
+cosign__release-1.4=1.4.2
+cosign__release-1.3=1.3.5
+
+# === Gitsign ===
+gitsign__main=1.5.0
+gitsign__release-1.4=1.4.2
+gitsign__release-1.3=1.3.5
+
+# === Certificate Transparency Go ===
+certificate-transparency-go__main=1.5.0
+certificate-transparency-go__release-1.4=1.4.2
+certificate-transparency-go__release-1.3=1.3.5
+
+# === Model Transparency Go ===
+model-transparency-go__main=1.5.0
+model-transparency-go__release-1.4=1.4.2
+model-transparency-go__release-1.3=1.3.5
+
+# === Rekor Search UI ===
+rekor-search-ui__main=1.5.0
+rekor-search-ui__release-1.4=1.4.2
+rekor-search-ui__release-1.3=1.3.5
+# ============================================================================
+# AUXILIARY COMPONENTS
+# Supporting tools and utilities
+# ============================================================================
+
+# === Artifact Signer Ansible ===
+artifact-signer-ansible__main=1.5.0
+artifact-signer-ansible__release-1.4=1.4.2
+artifact-signer-ansible__release-1.3=1.3.5
+
+# === Model Transparency ===
+model-transparency__main=0.1.0
+
+# === Model Validation Operator ===
+model-validation-operator__main=0.1.0
+
+# === Tough ===
+tough__develop=1.5.0
+tough__release-1.4=1.4.2
+tough__release-1.3=1.3.5
+
+# === Rekor Monitor ===
+rekor-monitor__main=1.5.0-dev
+rekor-monitor__release-1.4=1.4.2
+rekor-monitor__release-1.3=1.3.5
+
+# === Segment Backup Job ===
+segment-backup-job__main=1.5.0-dev
+segment-backup-job__release-1.4=1.4.2
+segment-backup-job__release-1.3=1.3.5
+
+# ============================================================================
+# POLICY CONTROLLER COMPONENTS
+# Separate release cycle from main RHTAS components
+# ============================================================================
+
+# === Policy Controller ===
+policy-controller__main=1.5.0-dev
+policy-controller__release-1.0=1.0.1
+
+# === Policy Controller Operator ===
+policy-controller-operator__main=1.1.0
+policy-controller-operator__release-1.0=1.0.1
+
+# ============================================================================
+# REPO-ONLY FALLBACKS
+# Used when exact repo__branch combination is not found
+# ============================================================================
+
+artifact-signer-ansible=1.5.0-dev
+certificate-transparency-go=1.5.0-dev
+cosign=1.5.0-dev
+fulcio=1.5.0-dev
+gitsign=1.5.0-dev
+model-transparency=1.5.0-dev
+model-transparency-go=1.5.0-dev
+model-validation-operator=1.5.0-dev
+policy-controller=1.5.0-dev
+policy-controller-operator=1.5.0-dev
+rekor=1.5.0-dev
+rekor-monitor=1.5.0-dev
+rekor-search-ui=1.5.0-dev
+rhtas-console=1.5.0-dev
+rhtas-console-ui=1.5.0-dev
+secure-sign-operator=1.5.0-dev
+segment-backup-job=1.5.0-dev
+timestamp-authority=1.5.0-dev
+tough=1.5.0-dev
+trillian=1.5.0-dev
+tuf-server=1.5.0-dev

--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -184,6 +184,27 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: get-version-from-configmap
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: "https://github.com/securesign/pipelines.git"
+      - name: revision
+        value: "main"
+      - name: pathInRepo
+        value: tasks/get-version-from-configmap.yaml
+    params:
+    - name: git-url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: configmap-name
+      value: rhtas-repo-branch-versions
+    - name: configmap-namespace
+      value: rhtas-tenant
+    - name: default-version
+      value: $(params.release-version)
   - name: derive-product-version
     taskRef:
       resolver: git
@@ -196,9 +217,11 @@ spec:
         value: tasks/derive-product-version.yaml
     params:
     - name: release-version
-      value: $(params.release-version)
+      value: $(tasks.get-version-from-configmap.results.release-version)
     - name: image-version
       value: $(params.image-version)
+    runAfter:
+    - get-version-from-configmap
   - name: generate-labels
     params:
     - name: label-templates

--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -202,6 +202,27 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: get-version-from-configmap
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: "https://github.com/securesign/pipelines.git"
+      - name: revision
+        value: "main"
+      - name: pathInRepo
+        value: tasks/get-version-from-configmap.yaml
+    params:
+    - name: git-url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: configmap-name
+      value: rhtas-repo-branch-versions
+    - name: configmap-namespace
+      value: rhtas-tenant
+    - name: default-version
+      value: $(params.release-version)
   - name: derive-product-version
     taskRef:
       resolver: git
@@ -214,9 +235,11 @@ spec:
         value: tasks/derive-product-version.yaml
     params:
     - name: release-version
-      value: $(params.release-version)
+      value: $(tasks.get-version-from-configmap.results.release-version)
     - name: image-version
       value: $(params.image-version)
+    runAfter:
+    - get-version-from-configmap
   - name: generate-labels
     params:
     - name: label-templates

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -185,6 +185,27 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: get-version-from-configmap
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: "https://github.com/securesign/pipelines.git"
+      - name: revision
+        value: "main"
+      - name: pathInRepo
+        value: tasks/get-version-from-configmap.yaml
+    params:
+    - name: git-url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: configmap-name
+      value: rhtas-repo-branch-versions
+    - name: configmap-namespace
+      value: rhtas-tenant
+    - name: default-version
+      value: $(params.release-version)
   - name: derive-product-version
     taskRef:
       resolver: git
@@ -197,9 +218,11 @@ spec:
         value: tasks/derive-product-version.yaml
     params:
     - name: release-version
-      value: $(params.release-version)
+      value: $(tasks.get-version-from-configmap.results.release-version)
     - name: image-version
       value: $(params.image-version)
+    runAfter:
+    - get-version-from-configmap
   - name: generate-labels
     params:
     - name: label-templates

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -200,6 +200,27 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: get-version-from-configmap
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: "https://github.com/securesign/pipelines.git"
+      - name: revision
+        value: "main"
+      - name: pathInRepo
+        value: tasks/get-version-from-configmap.yaml
+    params:
+    - name: git-url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: configmap-name
+      value: rhtas-repo-branch-versions
+    - name: configmap-namespace
+      value: rhtas-tenant
+    - name: default-version
+      value: $(params.release-version)
   - name: derive-product-version
     taskRef:
       resolver: git
@@ -212,9 +233,11 @@ spec:
         value: tasks/derive-product-version.yaml
     params:
     - name: release-version
-      value: $(params.release-version)
+      value: $(tasks.get-version-from-configmap.results.release-version)
     - name: image-version
       value: $(params.image-version)
+    runAfter:
+    - get-version-from-configmap
   - name: generate-labels
     params:
     - name: label-templates

--- a/tasks/get-version-from-configmap.yaml
+++ b/tasks/get-version-from-configmap.yaml
@@ -10,9 +10,6 @@ spec:
     - name: git-url
       description: Git repository URL (e.g., https://github.com/securesign/fulcio)
       type: string
-    - name: branch
-      description: Git branch name (e.g., release-1.4, main)
-      type: string
     - name: configmap-name
       description: Name of the ConfigMap containing version mappings
       type: string
@@ -38,10 +35,17 @@ spec:
         set -e
 
         GIT_URL="$(params.git-url)"
-        BRANCH="$(params.branch)"
         CM_NAME="$(params.configmap-name)"
         CM_NAMESPACE="$(params.configmap-namespace)"
         DEFAULT_VERSION="$(params.default-version)"
+
+        # Read branch from PipelineRun annotation
+        BRANCH="$(context.pipelineRun.annotations['build\.appstudio\.redhat\.com/target_branch'])"
+
+        if [ -z "${BRANCH}" ]; then
+          echo "❌ ERROR: Could not read target_branch from PipelineRun annotation 'build.appstudio.redhat.com/target_branch'"
+          exit 1
+        fi
 
         # Extract repository name from git URL
         # Examples:

--- a/tasks/get-version-from-configmap.yaml
+++ b/tasks/get-version-from-configmap.yaml
@@ -10,8 +10,8 @@ spec:
     - name: git-url
       description: Git repository URL (e.g., https://github.com/securesign/fulcio)
       type: string
-    - name: revision
-      description: Git branch or revision (e.g., release-1.4, main)
+    - name: branch
+      description: Git branch name (e.g., release-1.4, main)
       type: string
     - name: configmap-name
       description: Name of the ConfigMap containing version mappings
@@ -38,7 +38,7 @@ spec:
         set -e
 
         GIT_URL="$(params.git-url)"
-        REVISION="$(params.revision)"
+        BRANCH="$(params.branch)"
         CM_NAME="$(params.configmap-name)"
         CM_NAMESPACE="$(params.configmap-namespace)"
         DEFAULT_VERSION="$(params.default-version)"
@@ -51,7 +51,7 @@ spec:
 
         echo "Git URL: ${GIT_URL}"
         echo "Repository: ${REPO_NAME}"
-        echo "Branch/Revision: ${REVISION}"
+        echo "Branch: ${BRANCH}"
         echo "ConfigMap: ${CM_NAMESPACE}/${CM_NAME}"
         echo ""
 
@@ -60,7 +60,7 @@ spec:
         # 2. Repo fallback: <repo>
         # 3. Default fallback
 
-        LOOKUP_KEY="${REPO_NAME}__${REVISION}"
+        LOOKUP_KEY="${REPO_NAME}__${BRANCH}"
         echo "Looking up key: ${LOOKUP_KEY}"
 
         VERSION=$(oc get configmap "${CM_NAME}" -n "${CM_NAMESPACE}" \

--- a/tasks/get-version-from-configmap.yaml
+++ b/tasks/get-version-from-configmap.yaml
@@ -1,0 +1,93 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: get-version-from-configmap
+spec:
+  description: >
+    Looks up release version from ConfigMap based on git repository and branch.
+    Performs hierarchical lookup: <repo>__<branch> → <repo> → default fallback.
+  params:
+    - name: git-url
+      description: Git repository URL (e.g., https://github.com/securesign/fulcio)
+      type: string
+    - name: revision
+      description: Git branch or revision (e.g., release-1.4, main)
+      type: string
+    - name: configmap-name
+      description: Name of the ConfigMap containing version mappings
+      type: string
+      default: rhtas-repo-branch-versions
+    - name: configmap-namespace
+      description: Namespace where the ConfigMap is located
+      type: string
+      default: rhtas-tenant
+    - name: default-version
+      description: Fallback version if lookup fails
+      type: string
+      default: "0.0.0-dev"
+  results:
+    - name: release-version
+      description: The resolved release version from ConfigMap
+    - name: lookup-key
+      description: The key used for the successful lookup (for debugging)
+  steps:
+    - name: get-version
+      image: quay.io/openshift/origin-cli:4.15
+      script: |
+        #!/bin/bash
+        set -e
+
+        GIT_URL="$(params.git-url)"
+        REVISION="$(params.revision)"
+        CM_NAME="$(params.configmap-name)"
+        CM_NAMESPACE="$(params.configmap-namespace)"
+        DEFAULT_VERSION="$(params.default-version)"
+
+        # Extract repository name from git URL
+        # Examples:
+        #   https://github.com/securesign/fulcio → fulcio
+        #   https://github.com/securesign/fulcio.git → fulcio
+        REPO_NAME=$(echo "${GIT_URL}" | sed 's|.*/||' | sed 's|\.git$||')
+
+        echo "Git URL: ${GIT_URL}"
+        echo "Repository: ${REPO_NAME}"
+        echo "Branch/Revision: ${REVISION}"
+        echo "ConfigMap: ${CM_NAMESPACE}/${CM_NAME}"
+        echo ""
+
+        # Try hierarchical lookup:
+        # 1. Exact match: <repo>__<branch>
+        # 2. Repo fallback: <repo>
+        # 3. Default fallback
+
+        LOOKUP_KEY="${REPO_NAME}__${REVISION}"
+        echo "Looking up key: ${LOOKUP_KEY}"
+
+        VERSION=$(oc get configmap "${CM_NAME}" -n "${CM_NAMESPACE}" \
+          -o jsonpath="{.data.${LOOKUP_KEY}}" 2>/dev/null || echo "")
+
+        if [ -n "${VERSION}" ]; then
+          echo "✅ Found exact match: ${LOOKUP_KEY} = ${VERSION}"
+          echo -n "${VERSION}" > "$(results.release-version.path)"
+          echo -n "${LOOKUP_KEY}" > "$(results.lookup-key.path)"
+          exit 0
+        fi
+
+        # Fallback to repo-only key
+        LOOKUP_KEY="${REPO_NAME}"
+        echo "Exact match not found. Trying fallback key: ${LOOKUP_KEY}"
+
+        VERSION=$(oc get configmap "${CM_NAME}" -n "${CM_NAMESPACE}" \
+          -o jsonpath="{.data.${LOOKUP_KEY}}" 2>/dev/null || echo "")
+
+        if [ -n "${VERSION}" ]; then
+          echo "✅ Found repo fallback: ${LOOKUP_KEY} = ${VERSION}"
+          echo -n "${VERSION}" > "$(results.release-version.path)"
+          echo -n "${LOOKUP_KEY}" > "$(results.lookup-key.path)"
+          exit 0
+        fi
+
+        # Use default fallback
+        echo "⚠️  No ConfigMap entry found. Using default: ${DEFAULT_VERSION}"
+        echo -n "${DEFAULT_VERSION}" > "$(results.release-version.path)"
+        echo -n "default" > "$(results.lookup-key.path)"

--- a/tasks/get-version-from-configmap.yaml
+++ b/tasks/get-version-from-configmap.yaml
@@ -40,7 +40,7 @@ spec:
         DEFAULT_VERSION="$(params.default-version)"
 
         # Read branch from PipelineRun annotation
-        BRANCH="$(context.pipelineRun.annotations['build\.appstudio\.redhat\.com/target_branch'])"
+        BRANCH="$(context.pipelineRun.annotations['build.appstudio.redhat.com/target_branch'])"
 
         if [ -z "${BRANCH}" ]; then
           echo "❌ ERROR: Could not read target_branch from PipelineRun annotation 'build.appstudio.redhat.com/target_branch'"


### PR DESCRIPTION
This should hopefully eliminate the need to open 20+ prs post release. We can now localise tags in one place.