### PR TITLE
feat: onboard sigstore-a2a to Konflux with agent-card-validation stream

### DIFF
--- a/konflux-configs/base/project/kustomization.yaml
+++ b/konflux-configs/base/project/kustomization.yaml
@@ -18,5 +18,6 @@ resources:
   - overlay/model-validation-operator
   - overlay/model-transparency
   - overlay/model-transparency-go
+  - overlay/sigstore-a2a
   - overlay/cli-stacks
   - overlay/rhtas-console

--- a/konflux-configs/base/project/overlay/sigstore-a2a/kustomization.yaml
+++ b/konflux-configs/base/project/overlay/sigstore-a2a/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - template.yaml
+
+components:
+  - ../../base/ec
+  - ../../base/release-plan
+
+patches:
+  - target:
+      name: sigstore-a2a-template
+      kind: ProjectDevelopmentStreamTemplate
+    path: patch/sigstore-a2a.yaml

--- a/konflux-configs/base/project/overlay/sigstore-a2a/patch/sigstore-a2a.yaml
+++ b/konflux-configs/base/project/overlay/sigstore-a2a/patch/sigstore-a2a.yaml
@@ -1,0 +1,42 @@
+- op: add
+  path: /spec/resources/-
+  value:
+    apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+        git-provider: github
+        git-provider-url: https://github.com
+        mintmaker.appstudio.redhat.com/disabled: "{{.mintmakerDisabled}}"
+      name: "sigstore-a2a{{.nameSuffix}}"
+    spec:
+      application: "{{.application}}{{.nameSuffix}}"
+      componentName: sigstore-a2a
+      source:
+        git:
+          url: https://github.com/securesign/sigstore-a2a
+          revision: "{{.branch}}"
+          dockerfileUrl: Containerfile.rh
+- op: add
+  path: /spec/resources/-
+  value:
+    apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      name: "sigstore-a2a{{.nameSuffix}}"
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "{{.application}}{{.nameSuffix}}"
+        appstudio.redhat.com/component: "sigstore-a2a{{.nameSuffix}}"
+    spec:
+      image:
+        name: rhtas-tenant/sigstore-a2a
+        visibility: public
+      notifications:
+        - config:
+            url: https://bombino.api.redhat.com/v1/sbom/quay/push
+          event: repo_push
+          method: webhook
+          title: SBOM-event-to-Bombino

--- a/konflux-configs/base/project/overlay/sigstore-a2a/project.yaml
+++ b/konflux-configs/base/project/overlay/sigstore-a2a/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: Project
+metadata:
+  name: sigstore-a2a
+spec:
+  displayName: "Red Hat Trusted Artifact Signer sigstore-a2a"
+  description: |
+    sigstore-a2a - Keyless signing library for A2A Agent Cards using Sigstore and SLSA provenance.

--- a/konflux-configs/base/project/overlay/sigstore-a2a/template.yaml
+++ b/konflux-configs/base/project/overlay/sigstore-a2a/template.yaml
@@ -1,0 +1,33 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStreamTemplate
+metadata:
+  name: sigstore-a2a-template
+  labels:
+    build.rhtas.com/ec: registry-rhtas
+    build.rhtas.com/type: component
+spec:
+  project: sigstore-a2a
+  variables:
+    - name: version
+      description: A version number for a new development stream
+    - name: branch
+      description: Git branch
+      defaultValue: "main"
+    - name: nameSuffix
+      description: A suffix which will be added to K8s resource name
+      defaultValue: "-{{hyphenize .version}}"
+    - name: application
+      description: The application name
+      defaultValue: "sigstore-a2a"
+    - name: mintmakerDisabled
+      description: Whether to disable mintmaker annotation on the Component
+      defaultValue: "false"
+  resources:
+    - apiVersion: appstudio.redhat.com/v1alpha1
+      kind: Application
+      metadata:
+        annotations:
+          application.thumbnail: "5"
+        name: "{{.application}}{{.nameSuffix}}"
+      spec:
+        displayName: "{{.application}} ({{.version}})"

--- a/konflux-configs/base/stream/agent-card-validation/base/kustomization.yaml
+++ b/konflux-configs/base/stream/agent-card-validation/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - sigstore-a2a.yaml

--- a/konflux-configs/base/stream/agent-card-validation/base/sigstore-a2a.yaml
+++ b/konflux-configs/base/stream/agent-card-validation/base/sigstore-a2a.yaml
@@ -1,0 +1,15 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStream
+metadata:
+  name: sigstore-a2a
+spec:
+  project: sigstore-a2a
+  template:
+    name: sigstore-a2a-template
+    values:
+      - name: version
+        value: "main"
+      - name: branch
+        value: "main"
+      - name: nameSuffix
+        value: ""

--- a/konflux-configs/base/stream/agent-card-validation/overlay/kustomization.yaml
+++ b/konflux-configs/base/stream/agent-card-validation/overlay/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - main

--- a/konflux-configs/base/stream/agent-card-validation/overlay/main/kustomization.yaml
+++ b/konflux-configs/base/stream/agent-card-validation/overlay/main/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -main
+
+components:
+  - ../../base/
+
+configurations:
+  - kustomizeconfig.yaml

--- a/konflux-configs/base/stream/agent-card-validation/overlay/main/kustomizeconfig.yaml
+++ b/konflux-configs/base/stream/agent-card-validation/overlay/main/kustomizeconfig.yaml
@@ -1,0 +1,21 @@
+nameReference:
+- kind: Project
+  version: v1beta1
+  group: projctl.konflux.dev
+  fieldSpecs:
+  - path: spec/project
+    kind: ProjectDevelopmentStreamTemplate
+    group: projctl.konflux.dev
+    version: v1beta1
+  - path: spec/project
+    kind: ProjectDevelopmentStream
+    group: projctl.konflux.dev
+    version: v1beta1
+- kind: ProjectDevelopmentStreamTemplate
+  version: v1beta1
+  group: projctl.konflux.dev
+  fieldSpecs:
+  - path: spec/template/name
+    kind: ProjectDevelopmentStream
+    group: projctl.konflux.dev
+    version: v1beta1

--- a/konflux-configs/base/stream/kustomization.yaml
+++ b/konflux-configs/base/stream/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - rhtas/overlay
   - policy-controller/overlay
   - model-validation/overlay
+  - agent-card-validation/overlay


### PR DESCRIPTION
## Summary

- Add Konflux project overlay for **sigstore-a2a** under `konflux-configs/base/project/overlay/sigstore-a2a/` following the model-transparency-go pattern
- Create **agent-card-validation** stream group under `konflux-configs/base/stream/agent-card-validation/` with a `main` stream
- Component points to `securesign/sigstore-a2a` repo with `Containerfile.rh` for builds
- ImageRepository configured in `rhtas-tenant` with Bombino SBOM webhook
- EC integration test and ReleasePlan included via shared kustomize components
- Validated: `kustomize build` renders 376 resources with no errors

## Files

**Project overlay (4 files):**
- `project.yaml` — Project definition
- `template.yaml` — ProjectDevelopmentStreamTemplate with variables
- `patch/sigstore-a2a.yaml` — Component + ImageRepository patch
- `kustomization.yaml` — wires it all together with EC and ReleasePlan

**Stream group (5 files):**
- `base/sigstore-a2a.yaml` — ProjectDevelopmentStream for main branch
- `base/kustomization.yaml` — Component listing
- `overlay/main/` — main stream with kustomize nameReference config
- `overlay/kustomization.yaml` — overlay entry point

**Modified (2 files):**
- `base/project/kustomization.yaml` — added `overlay/sigstore-a2a`
- `base/stream/kustomization.yaml` — added `agent-card-validation/overlay`

Implements [SECURESIGN-4635](https://redhat.atlassian.net/browse/SECURESIGN-4635)

[SECURESIGN-4635]: https://redhat.atlassian.net/browse/SECURESIGN-4635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ