### PR TITLE
fix: update nudge chain for cli-stack architecture

### DIFF
--- a/konflux-configs/base/project/overlay/cli-stacks/patch/cosign-cli-stack.yaml
+++ b/konflux-configs/base/project/overlay/cli-stacks/patch/cosign-cli-stack.yaml
@@ -13,6 +13,8 @@
     spec:
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "cosign-cli-stack"
+      build-nudges-ref:
+        - "client-server{{.nameSuffix}}"
       source:
         git:
           url: https://github.com/securesign/cosign

--- a/konflux-configs/base/project/overlay/cli-stacks/patch/fetch-tsa-certs-cli-stack.yaml
+++ b/konflux-configs/base/project/overlay/cli-stacks/patch/fetch-tsa-certs-cli-stack.yaml
@@ -13,6 +13,8 @@
     spec:
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "fetch-tsa-certs-cli-stack"
+      build-nudges-ref:
+        - "client-server{{.nameSuffix}}"
       source:
         git:
           url: https://github.com/securesign/timestamp-authority

--- a/konflux-configs/base/project/overlay/cli-stacks/patch/gitsign-cli-stack.yaml
+++ b/konflux-configs/base/project/overlay/cli-stacks/patch/gitsign-cli-stack.yaml
@@ -13,6 +13,8 @@
     spec:
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "gitsign-cli-stack"
+      build-nudges-ref:
+        - "client-server{{.nameSuffix}}"
       source:
         git:
           url: https://github.com/securesign/gitsign

--- a/konflux-configs/base/project/overlay/cli-stacks/patch/rekor-cli-stack.yaml
+++ b/konflux-configs/base/project/overlay/cli-stacks/patch/rekor-cli-stack.yaml
@@ -13,6 +13,8 @@
     spec:
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "rekor-cli-stack"
+      build-nudges-ref:
+        - "client-server{{.nameSuffix}}"
       source:
         git:
           url: https://github.com/securesign/rekor

--- a/konflux-configs/base/project/overlay/cli-stacks/patch/trillian-cli-stack.yaml
+++ b/konflux-configs/base/project/overlay/cli-stacks/patch/trillian-cli-stack.yaml
@@ -13,6 +13,8 @@
     spec:
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "trillian-cli-stack"
+      build-nudges-ref:
+        - "client-server{{.nameSuffix}}"
       source:
         git:
           url: https://github.com/securesign/trillian

--- a/konflux-configs/base/project/overlay/cli-stacks/patch/tuftool-cli-stack.yaml
+++ b/konflux-configs/base/project/overlay/cli-stacks/patch/tuftool-cli-stack.yaml
@@ -13,6 +13,8 @@
     spec:
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "tuftool-cli-stack"
+      build-nudges-ref:
+        - "client-server{{.nameSuffix}}"
       source:
         git:
           url: https://github.com/securesign/tough

--- a/konflux-configs/base/project/overlay/create-tree/patch/create-tree.yaml
+++ b/konflux-configs/base/project/overlay/create-tree/patch/create-tree.yaml
@@ -16,7 +16,6 @@
       build-nudges-ref:
         - "artifact-signer-ansible{{.nameSuffix}}"
         - "rhtas-operator{{.nameSuffix}}"
-        - "client-server{{.nameSuffix}}"
         - "trillian-cli-stack{{.nameSuffix}}"
       source:
         git:

--- a/konflux-configs/base/project/overlay/tas-tools/patch/cosign.yaml
+++ b/konflux-configs/base/project/overlay/tas-tools/patch/cosign.yaml
@@ -14,7 +14,6 @@
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "cosign"
       build-nudges-ref:
-        - "client-server{{.nameSuffix}}"
         - "cosign-cli-stack{{.nameSuffix}}"
       source:
         git:

--- a/konflux-configs/base/project/overlay/tas-tools/patch/fetch-tsa.yaml
+++ b/konflux-configs/base/project/overlay/tas-tools/patch/fetch-tsa.yaml
@@ -14,7 +14,6 @@
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "fetch-tsa-certs"
       build-nudges-ref:
-        - "client-server{{.nameSuffix}}"
         - "fetch-tsa-certs-cli-stack{{.nameSuffix}}"
       source:
         git:

--- a/konflux-configs/base/project/overlay/tas-tools/patch/gitsign.yaml
+++ b/konflux-configs/base/project/overlay/tas-tools/patch/gitsign.yaml
@@ -14,7 +14,6 @@
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "gitsign"
       build-nudges-ref:
-        - "client-server{{.nameSuffix}}"
         - "gitsign-cli-stack{{.nameSuffix}}"
       source:
         git:

--- a/konflux-configs/base/project/overlay/tas-tools/patch/rekor-cli.yaml
+++ b/konflux-configs/base/project/overlay/tas-tools/patch/rekor-cli.yaml
@@ -14,7 +14,6 @@
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "rekor-cli"
       build-nudges-ref:
-        - "client-server{{.nameSuffix}}"
         - "rekor-cli-stack{{.nameSuffix}}"
       source:
         git:

--- a/konflux-configs/base/project/overlay/tas-tools/patch/update-tree.yaml
+++ b/konflux-configs/base/project/overlay/tas-tools/patch/update-tree.yaml
@@ -14,7 +14,6 @@
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "updatetree"
       build-nudges-ref:
-        - "client-server{{.nameSuffix}}"
         - "trillian-cli-stack{{.nameSuffix}}"
       source:
         git:

--- a/konflux-configs/base/project/overlay/tough/patch/tuf-tool.yaml
+++ b/konflux-configs/base/project/overlay/tough/patch/tuf-tool.yaml
@@ -14,7 +14,6 @@
       application: "{{.application}}{{.nameSuffix}}"
       componentName: "tuf-tool"
       build-nudges-ref:
-        - "client-server{{.nameSuffix}}"
         - "tuftool-cli-stack{{.nameSuffix}}"
       source:
         git:


### PR DESCRIPTION
## Summary
Client-server now consumes cli-stack images instead of component images directly. Update the nudge chain from:
```
component → [cli-stack, client-server]  (old)
```
to:
```
component → cli-stack → client-server  (new)
```

### Changes
**Removed `client-server` from component nudges** (7 files):
- `tas-tools/cosign.yaml`, `gitsign.yaml`, `rekor-cli.yaml`, `fetch-tsa.yaml`, `update-tree.yaml`
- `create-tree/create-tree.yaml`
- `tough/tuf-tool.yaml`

**Added `client-server` to cli-stack nudges** (6 files):
- `cli-stacks/cosign-cli-stack.yaml`, `gitsign-cli-stack.yaml`, `rekor-cli-stack.yaml`
- `cli-stacks/fetch-tsa-certs-cli-stack.yaml`, `trillian-cli-stack.yaml`, `tuftool-cli-stack.yaml`

This ensures the correct build order: component rebuilds → nudges cli-stack → cli-stack rebuilds → nudges client-server → client-server rebuilds with updated cli-stack digests.

## Test plan
- [ ] Verify nudge chain triggers correctly: component rebuild → cli-stack rebuild → client-server rebuild
- [ ] No direct component → client-server nudges remain for tools that go through cli-stacks