### PR TITLE
Add ALLOW_CROSS_PLATFORM_IMAGES parameter support

### DIFF
--- a/pipelines/bundle-build-oci-ta.yaml
+++ b/pipelines/bundle-build-oci-ta.yaml
@@ -103,6 +103,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    type: string
+    default: "false"
+    description: Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.
   results:
   - description: ""
     name: IMAGE_URL
@@ -277,6 +281,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     runAfter:
     - prefetch-dependencies
     - generate-labels

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -107,6 +107,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    type: string
+    default: "false"
+    description: Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.
   results:
   - description: ""
     name: IMAGE_URL
@@ -258,6 +262,8 @@ spec:
       - "short-commit=$(tasks.clone-repository.results.short-commit)"
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     runAfter:
     - prefetch-dependencies
     - generate-labels


### PR DESCRIPTION
## Summary
This PR adds support for the `ALLOW_CROSS_PLATFORM_IMAGES` parameter to enable building images with multi-architecture parent images.

## Changes
- Added `ALLOW_CROSS_PLATFORM_IMAGES` pipeline parameter to both `docker-build-oci-ta` and `bundle-build-oci-ta` pipelines
- Parameter defaults to `false` for safety
- Passes the parameter through to the `buildah-oci-ta` task's build-container step
- Both pipelines already use buildah-oci-ta:0.10 which supports this parameter (added in v0.10.3)

## Context
This is required for CLI stack builds that use `FROM --platform=<arch>` statements to pull platform-specific base images. Without this parameter, buildah v0.10+ rejects cross-platform parent images with an error:

```
base image has architecture 'arm64', expected 'amd64'. Use a multi-arch image reference instead of a single-architecture reference, or explicitly allow cross-platform images in the build configuration
```

## Usage
Components that need cross-platform image support can set this in their `.tekton` PipelineRun files:
```yaml
  params:
  - name: ALLOW_CROSS_PLATFORM_IMAGES
    value: "true"
```

## Related
- Buildah task changelog: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/CHANGELOG.md#0103
- Enables building cosign-cli-stack and similar multi-arch binary distribution images

🤖 Generated with [Claude Code](https://claude.com/claude-code)