### PR TITLE
fix: migrate playwright-go to mxschmitt/playwright-go (CDN shutdown)

### DIFF
--- a/tasks/integration-test/sigstore-e2e.yaml
+++ b/tasks/integration-test/sigstore-e2e.yaml
@@ -149,7 +149,7 @@ spec:
           libxcb libXcomposite libXdamage libXext libXfixes libxkbcommon \
           libXrandr libxshmfence mesa-libgbm nss nspr pango
 
-        go run github.com/playwright-community/playwright-go/cmd/playwright install chromium
+        go run github.com/mxschmitt/playwright-go/cmd/playwright install chromium
         go mod vendor
 
         export TEST_FIREFOX=false


### PR DESCRIPTION
## Summary

- Migrate `playwright-community/playwright-go` → `mxschmitt/playwright-go` (one-line change)
- The Playwright `/builds/driver` CDN (azureedge) has been shut down — `playwright install` fails with 404
- The module moved to `mxschmitt/playwright-go` which downloads the driver from npm + nodejs.org instead ([PR #615](https://github.com/playwright-community/playwright-go/pull/615))

### Related PRs
- sigstore-e2e: https://github.com/securesign/sigstore-e2e/pull/80
- releases: https://github.com/securesign/releases/pull/291
- Jira: [SECURESIGN-4984](https://redhat.atlassian.net/browse/SECURESIGN-4984)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SECURESIGN-4984]: https://redhat.atlassian.net/browse/SECURESIGN-4984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ