### PR TITLE
feat: add ALLOW_CROSS_PLATFORM_IMAGES param to multi-platform pipeline

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta.yaml
@@ -83,6 +83,10 @@ spec:
     description: Name of the Dockerfile ARG to inject with the resolved dependency image (e.g. IMG, AGENT_IMG).
     name: manager-build-arg-name
     type: string
+  - default: "false"
+    description: Allow base images with a different architecture than the target platform. Required when extracting binaries from a single-arch image (e.g. cli-stack) in a multi-platform build.
+    name: ALLOW_CROSS_PLATFORM_IMAGES
+    type: string
   - default:
     - linux/x86_64
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
@@ -298,6 +302,8 @@ spec:
       - "short-commit=$(tasks.clone-repository.results.short-commit)"
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     runAfter:
     - prefetch-dependencies
     - generate-labels


### PR DESCRIPTION
## Summary

- Expose `ALLOW_CROSS_PLATFORM_IMAGES` parameter in `docker-build-multi-platform-oci-ta.yaml`, matching existing support in `docker-build-oci-ta.yaml` and `bundle-build-oci-ta.yaml`
- The `buildah-remote-oci-ta` task already reads this env var but the multi-platform pipeline did not expose it — defaults to `"false"` so **all existing builds are unaffected**

### Why

The inverted cli-stack build flow (securesign/timestamp-authority#391) has a multi-platform component image that extracts binaries from a single-arch cli-stack image via the `wait-for-pipelinerun` mechanism. Non-amd64 builders reject the amd64 cli-stack image without `ALLOW_CROSS_PLATFORM_IMAGES=true`.

## Test plan

- [ ] Existing builds (cosign, gitsign, rekor, etc.) continue to work — they don't set this param, so default `"false"` applies
- [ ] timestamp-authority inverted flow PR [(#391) ](https://github.com/securesign/timestamp-authority/pull/391) passes all platform builds with `ALLOW_CROSS_PLATFORM_IMAGES: "true"`
